### PR TITLE
Refactor schedulers and PeersClient to use channel-based Actor<T> bas…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+.claude/

--- a/Netorrent/ActorSystem/Actor.cs
+++ b/Netorrent/ActorSystem/Actor.cs
@@ -1,0 +1,107 @@
+using System.Threading.Channels;
+
+namespace Netorrent.ActorSystem;
+
+internal abstract class Actor<TMessage> : IAsyncDisposable
+{
+    private readonly Channel<TMessage> _mailbox = Channel.CreateBounded<TMessage>(
+        new BoundedChannelOptions(128) { SingleWriter = false, SingleReader = true }
+    );
+    private readonly List<Timer> _timers = [];
+    private CancellationTokenSource? _cts;
+    private Task? _runningTask;
+    private bool _disposed;
+
+    protected ChannelReader<TMessage> MailboxReader => _mailbox.Reader;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_runningTask is not null)
+        {
+            throw new InvalidOperationException("Actor already started.");
+        }
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _runningTask = RunAsync(_cts.Token);
+        return _runningTask;
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await OnStartedAsync(cancellationToken).ConfigureAwait(false);
+            await foreach (
+                var message in _mailbox.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false)
+            )
+            {
+                await OnReceiveAsync(message, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            DisposeTimers();
+            await OnStoppingAsync().ConfigureAwait(false);
+        }
+    }
+
+    protected abstract ValueTask OnReceiveAsync(
+        TMessage message,
+        CancellationToken cancellationToken
+    );
+
+    protected virtual Task OnStartedAsync(CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+
+    protected virtual ValueTask OnStoppingAsync() => ValueTask.CompletedTask;
+
+    protected bool Tell(TMessage message) => _mailbox.Writer.TryWrite(message);
+
+    protected ValueTask SendAsync(TMessage message, CancellationToken cancellationToken) =>
+        _mailbox.Writer.WriteAsync(message, cancellationToken);
+
+    protected void ScheduleRepeatedly(TimeSpan delay, TimeSpan interval, TMessage message)
+    {
+        if (delay == TimeSpan.Zero)
+        {
+            _mailbox.Writer.TryWrite(message);
+            delay = interval;
+        }
+        var timer = new Timer(_ => _mailbox.Writer.TryWrite(message), null, delay, interval);
+        _timers.Add(timer);
+    }
+
+    protected virtual ValueTask DrainAsync() => ValueTask.CompletedTask;
+
+    private void DisposeTimers()
+    {
+        foreach (var timer in _timers)
+        {
+            timer.Dispose();
+        }
+        _timers.Clear();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_disposed)
+        {
+            _disposed = true;
+            _cts?.Cancel();
+            _mailbox.Writer.TryComplete();
+
+            try
+            {
+                if (_runningTask is not null)
+                {
+                    await _runningTask.ConfigureAwait(false);
+                }
+            }
+            catch { }
+
+            DisposeTimers();
+            await DrainAsync().ConfigureAwait(false);
+            _cts?.Dispose();
+        }
+    }
+}

--- a/Netorrent/ActorSystem/Actor.cs
+++ b/Netorrent/ActorSystem/Actor.cs
@@ -8,6 +8,7 @@ internal sealed class Actor<TMessage> : IAsyncDisposable
         new BoundedChannelOptions(128) { SingleWriter = false, SingleReader = true }
     );
     private readonly List<Timer> _timers = [];
+    private Timer? _scheduledTimer;
     private CancellationTokenSource? _cts;
     private Task? _runningTask;
     private bool _disposed;
@@ -66,13 +67,33 @@ internal sealed class Actor<TMessage> : IAsyncDisposable
         _timers.Add(timer);
     }
 
+    public void ScheduleOnce(TimeSpan delay, TMessage message)
+    {
+        if (_scheduledTimer is null)
+            _scheduledTimer = new Timer(
+                _ => _mailbox.Writer.TryWrite(message),
+                null,
+                delay,
+                Timeout.InfiniteTimeSpan
+            );
+        else
+            _scheduledTimer.Change(delay, Timeout.InfiniteTimeSpan);
+    }
+
+    public void CancelScheduled() =>
+        _scheduledTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
     private async ValueTask DisposeTimersAsync()
     {
         foreach (var timer in _timers)
-        {
             await timer.DisposeAsync().ConfigureAwait(false);
-        }
         _timers.Clear();
+
+        if (_scheduledTimer is not null)
+        {
+            await _scheduledTimer.DisposeAsync().ConfigureAwait(false);
+            _scheduledTimer = null;
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/Netorrent/ActorSystem/Actor.cs
+++ b/Netorrent/ActorSystem/Actor.cs
@@ -17,10 +17,11 @@ internal abstract class Actor<TMessage> : IAsyncDisposable
     public Task StartAsync(CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        if (_runningTask is not null)
+        if (_runningTask is { IsCompleted: false })
         {
             throw new InvalidOperationException("Actor already started.");
         }
+        _cts?.Dispose();
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _runningTask = RunAsync(_cts.Token);
         return _runningTask;

--- a/Netorrent/ActorSystem/Actor.cs
+++ b/Netorrent/ActorSystem/Actor.cs
@@ -46,7 +46,7 @@ internal sealed class Actor<TMessage> : IAsyncDisposable
         }
         finally
         {
-            DisposeTimers();
+            await DisposeTimersAsync().ConfigureAwait(false);
         }
     }
 
@@ -66,11 +66,11 @@ internal sealed class Actor<TMessage> : IAsyncDisposable
         _timers.Add(timer);
     }
 
-    private void DisposeTimers()
+    private async ValueTask DisposeTimersAsync()
     {
         foreach (var timer in _timers)
         {
-            timer.Dispose();
+            await timer.DisposeAsync().ConfigureAwait(false);
         }
         _timers.Clear();
     }
@@ -92,7 +92,7 @@ internal sealed class Actor<TMessage> : IAsyncDisposable
             }
             catch { }
 
-            DisposeTimers();
+            await DisposeTimersAsync().ConfigureAwait(false);
             _cts?.Dispose();
         }
     }

--- a/Netorrent/ActorSystem/Actor.cs
+++ b/Netorrent/ActorSystem/Actor.cs
@@ -2,7 +2,7 @@ using System.Threading.Channels;
 
 namespace Netorrent.ActorSystem;
 
-internal abstract class Actor<TMessage> : IAsyncDisposable
+internal sealed class Actor<TMessage> : IAsyncDisposable
 {
     private readonly Channel<TMessage> _mailbox = Channel.CreateBounded<TMessage>(
         new BoundedChannelOptions(128) { SingleWriter = false, SingleReader = true }
@@ -12,9 +12,12 @@ internal abstract class Actor<TMessage> : IAsyncDisposable
     private Task? _runningTask;
     private bool _disposed;
 
-    protected ChannelReader<TMessage> MailboxReader => _mailbox.Reader;
+    public ChannelReader<TMessage> MailboxReader => _mailbox.Reader;
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public Task StartAsync(
+        Func<TMessage, CancellationToken, ValueTask> onReceive,
+        CancellationToken cancellationToken
+    )
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_runningTask is { IsCompleted: false })
@@ -23,45 +26,36 @@ internal abstract class Actor<TMessage> : IAsyncDisposable
         }
         _cts?.Dispose();
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _runningTask = RunAsync(_cts.Token);
+        _runningTask = RunAsync(onReceive, _cts.Token);
         return _runningTask;
     }
 
-    private async Task RunAsync(CancellationToken cancellationToken)
+    private async Task RunAsync(
+        Func<TMessage, CancellationToken, ValueTask> onReceive,
+        CancellationToken cancellationToken
+    )
     {
         try
         {
-            await OnStartedAsync(cancellationToken).ConfigureAwait(false);
             await foreach (
                 var message in _mailbox.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false)
             )
             {
-                await OnReceiveAsync(message, cancellationToken).ConfigureAwait(false);
+                await onReceive(message, cancellationToken).ConfigureAwait(false);
             }
         }
         finally
         {
             DisposeTimers();
-            await OnStoppingAsync().ConfigureAwait(false);
         }
     }
 
-    protected abstract ValueTask OnReceiveAsync(
-        TMessage message,
-        CancellationToken cancellationToken
-    );
+    public bool Tell(TMessage message) => _mailbox.Writer.TryWrite(message);
 
-    protected virtual Task OnStartedAsync(CancellationToken cancellationToken) =>
-        Task.CompletedTask;
-
-    protected virtual ValueTask OnStoppingAsync() => ValueTask.CompletedTask;
-
-    protected bool Tell(TMessage message) => _mailbox.Writer.TryWrite(message);
-
-    protected ValueTask SendAsync(TMessage message, CancellationToken cancellationToken) =>
+    public ValueTask SendAsync(TMessage message, CancellationToken cancellationToken) =>
         _mailbox.Writer.WriteAsync(message, cancellationToken);
 
-    protected void ScheduleRepeatedly(TimeSpan delay, TimeSpan interval, TMessage message)
+    public void ScheduleRepeatedly(TimeSpan delay, TimeSpan interval, TMessage message)
     {
         if (delay == TimeSpan.Zero)
         {
@@ -71,8 +65,6 @@ internal abstract class Actor<TMessage> : IAsyncDisposable
         var timer = new Timer(_ => _mailbox.Writer.TryWrite(message), null, delay, interval);
         _timers.Add(timer);
     }
-
-    protected virtual ValueTask DrainAsync() => ValueTask.CompletedTask;
 
     private void DisposeTimers()
     {
@@ -101,7 +93,6 @@ internal abstract class Actor<TMessage> : IAsyncDisposable
             catch { }
 
             DisposeTimers();
-            await DrainAsync().ConfigureAwait(false);
             _cts?.Dispose();
         }
     }

--- a/Netorrent/IO/MessageStream.cs
+++ b/Netorrent/IO/MessageStream.cs
@@ -222,23 +222,17 @@ internal class MessageStream(
 
             case IdRequest:
             {
-                int requestPayloadLength = length - 1;
-
-                if (requestPayloadLength < 12)
-                {
+                if (length - 1 < 12)
                     return false;
-                }
 
-                using var requestMemoryOwner = MemoryPool<byte>.Shared.Rent(requestPayloadLength);
+                Span<byte> requestSpan = stackalloc byte[12];
+                buffer.Slice(5, 12).CopyTo(requestSpan);
 
-                Span<byte> requestSpan = requestMemoryOwner.Memory.Span[..requestPayloadLength];
-                buffer.Slice(5, requestPayloadLength).CopyTo(requestSpan);
-
-                var reqIndex = BinaryPrimitives.ReadInt32BigEndian(requestSpan[..4]);
-                var reqBegin = BinaryPrimitives.ReadInt32BigEndian(requestSpan[4..8]);
-                var reqLength = BinaryPrimitives.ReadInt32BigEndian(requestSpan[8..12]);
-
-                message = new RequestBlockMessage(reqIndex, reqBegin, reqLength);
+                message = new RequestBlockMessage(
+                    BinaryPrimitives.ReadInt32BigEndian(requestSpan[..4]),
+                    BinaryPrimitives.ReadInt32BigEndian(requestSpan[4..8]),
+                    BinaryPrimitives.ReadInt32BigEndian(requestSpan[8..12])
+                );
 
                 buffer = buffer.Slice(4 + length);
                 return true;
@@ -246,23 +240,17 @@ internal class MessageStream(
 
             case IdCancel:
             {
-                int cancelPayloadLength = length - 1;
-
-                if (cancelPayloadLength < 12)
-                {
+                if (length - 1 < 12)
                     return false;
-                }
 
-                using var cancelMemoryOwner = MemoryPool<byte>.Shared.Rent(cancelPayloadLength);
+                Span<byte> cancelSpan = stackalloc byte[12];
+                buffer.Slice(5, 12).CopyTo(cancelSpan);
 
-                Span<byte> cancelSpan = cancelMemoryOwner.Memory.Span[..cancelPayloadLength];
-                buffer.Slice(5, cancelPayloadLength).CopyTo(cancelSpan);
-
-                var cancelIndex = BinaryPrimitives.ReadInt32BigEndian(cancelSpan[..4]);
-                var cancelBegin = BinaryPrimitives.ReadInt32BigEndian(cancelSpan[4..8]);
-                var cancelLength = BinaryPrimitives.ReadInt32BigEndian(cancelSpan[8..12]);
-
-                message = new CancelMessage(cancelIndex, cancelBegin, cancelLength);
+                message = new CancelMessage(
+                    BinaryPrimitives.ReadInt32BigEndian(cancelSpan[..4]),
+                    BinaryPrimitives.ReadInt32BigEndian(cancelSpan[4..8]),
+                    BinaryPrimitives.ReadInt32BigEndian(cancelSpan[8..12])
+                );
 
                 buffer = buffer.Slice(4 + length);
                 return true;

--- a/Netorrent/P2P/Download/RequestScheduler.cs
+++ b/Netorrent/P2P/Download/RequestScheduler.cs
@@ -1,5 +1,5 @@
-using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using Netorrent.ActorSystem;
 using Netorrent.Extensions;
 using Netorrent.IO;
 using Netorrent.P2P.Messages;
@@ -17,75 +17,58 @@ internal class RequestScheduler(
     TimeSpan timeoutTime,
     IPieceStorage pieceStorage,
     ILogger logger
-) : IRequestScheduler
+) : Actor<DownloadMessage>, IRequestScheduler
 {
     const int MinPeersForRarity = 6;
 
-    private readonly Channel<DownloadMessage> _downloadMessageChannel =
-        Channel.CreateBounded<DownloadMessage>(
-            new BoundedChannelOptions(128) { SingleWriter = false, SingleReader = true }
-        );
-
     private static readonly DownloadMessage.CheckTimeoutMessage _timeoutMessage = new();
     private readonly Dictionary<int, PieceBuffer> _pieceBuffers = [];
-    private CancellationTokenSource? _cts;
-    private Task? _runningTask;
-    private bool _disposed;
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task OnStartedAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _runningTask = Task.RunUntilFirstCompletesAsync(
-            [ScheduleTimeoutsBlocksAsync, ProcessDownloadMessagesAsync],
-            _cts
-        );
-        return _runningTask;
-    }
-
-    private async Task ScheduleTimeoutsBlocksAsync(CancellationToken cancellationToken)
-    {
-        while (true)
-        {
-            await _downloadMessageChannel
-                .Writer.WriteAsync(_timeoutMessage, cancellationToken)
-                .ConfigureAwait(false);
-            await Task.Delay(1.Seconds, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private async Task ProcessDownloadMessagesAsync(CancellationToken cancellationToken)
-    {
+        ScheduleRepeatedly(TimeSpan.Zero, 1.Seconds, _timeoutMessage);
         await WarmupAsync(cancellationToken).ConfigureAwait(false);
-        await foreach (
-            var downloadMessage in _downloadMessageChannel
-                .Reader.ReadAllAsync(cancellationToken)
-                .ConfigureAwait(false)
-        )
+    }
+
+    protected override async ValueTask OnReceiveAsync(
+        DownloadMessage message,
+        CancellationToken cancellationToken
+    )
+    {
+        switch (message)
         {
-            if (downloadMessage is DownloadMessage.BlockMessage blockMessage)
-            {
+            case DownloadMessage.BlockMessage blockMessage:
                 await ProcessBlockAsync(blockMessage.Block, cancellationToken)
                     .ConfigureAwait(false);
-                continue;
-            }
-
-            if (downloadMessage is DownloadMessage.CheckTimeoutMessage)
-            {
+                break;
+            case DownloadMessage.CheckTimeoutMessage:
                 CheckTimeout();
-                continue;
-            }
-
-            if (downloadMessage is DownloadMessage.ScheduleMessage scheduleMessage)
-            {
+                break;
+            case DownloadMessage.ScheduleMessage scheduleMessage:
                 ScheduleRequests(scheduleMessage.PeerConnection);
                 if (piecePicker.IsEndGame)
                 {
                     ScheduleRequests();
                 }
-                continue;
+                break;
+        }
+    }
+
+    protected override async ValueTask DrainAsync()
+    {
+        await foreach (var item in MailboxReader.ReadAllAsync().ConfigureAwait(false))
+        {
+            if (item is DownloadMessage.BlockMessage blockMessage)
+            {
+                blockMessage.Dispose();
             }
         }
+
+        foreach (var (_, item) in _pieceBuffers)
+        {
+            item.Dispose();
+        }
+        _pieceBuffers.Clear();
     }
 
     private async ValueTask ProcessBlockAsync(Block block, CancellationToken cancellationToken)
@@ -169,9 +152,7 @@ internal class RequestScheduler(
 
             if (freePeer is not null)
             {
-                _downloadMessageChannel.Writer.TryWrite(
-                    new DownloadMessage.ScheduleMessage(freePeer)
-                );
+                Tell(new DownloadMessage.ScheduleMessage(freePeer));
             }
         }
     }
@@ -250,9 +231,7 @@ internal class RequestScheduler(
     {
         if (!peerConnection.PeerChoking.CurrentValue && peerConnection.AmInterested.CurrentValue)
         {
-            _downloadMessageChannel.Writer.TryWrite(
-                new DownloadMessage.ScheduleMessage(peerConnection)
-            );
+            Tell(new DownloadMessage.ScheduleMessage(peerConnection));
         }
     }
 
@@ -269,48 +248,17 @@ internal class RequestScheduler(
         return DateTimeOffset.UtcNow + Math.Min(timeoutSeconds, 60).Seconds;
     }
 
-    public async ValueTask ReceiveBlockAsync(Block block, CancellationToken cancellationToken) =>
-        await _downloadMessageChannel
-            .Writer.WriteOrDisposeAsync(new DownloadMessage.BlockMessage(block), cancellationToken)
-            .ConfigureAwait(false);
-
-    private async ValueTask DrainChannelsAsync()
+    public async ValueTask ReceiveBlockAsync(Block block, CancellationToken cancellationToken)
     {
-        await foreach (
-            var item in _downloadMessageChannel.Reader.ReadAllAsync().ConfigureAwait(false)
-        )
+        var message = new DownloadMessage.BlockMessage(block);
+        try
         {
-            if (item is DownloadMessage.BlockMessage blockMessage)
-            {
-                blockMessage.Dispose();
-            }
+            await SendAsync(message, cancellationToken).ConfigureAwait(false);
         }
-
-        foreach (var (_, item) in _pieceBuffers)
+        catch
         {
-            item.Dispose();
-        }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (!_disposed)
-        {
-            _disposed = true;
-            _cts?.Cancel();
-            _downloadMessageChannel.Writer.TryComplete();
-
-            try
-            {
-                if (_runningTask is not null)
-                {
-                    await _runningTask.ConfigureAwait(false);
-                }
-            }
-            catch { }
-
-            await DrainChannelsAsync().ConfigureAwait(false);
-            _cts?.Dispose();
+            message.Dispose();
+            throw;
         }
     }
 }

--- a/Netorrent/P2P/Download/RequestScheduler.cs
+++ b/Netorrent/P2P/Download/RequestScheduler.cs
@@ -17,20 +17,22 @@ internal class RequestScheduler(
     TimeSpan timeoutTime,
     IPieceStorage pieceStorage,
     ILogger logger
-) : Actor<DownloadMessage>, IRequestScheduler
+) : IRequestScheduler
 {
     const int MinPeersForRarity = 6;
 
+    private readonly Actor<DownloadMessage> _actor = new();
     private static readonly DownloadMessage.CheckTimeoutMessage _timeoutMessage = new();
     private readonly Dictionary<int, PieceBuffer> _pieceBuffers = [];
 
-    protected override async Task OnStartedAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        ScheduleRepeatedly(TimeSpan.Zero, 1.Seconds, _timeoutMessage);
+        _actor.ScheduleRepeatedly(TimeSpan.Zero, 1.Seconds, _timeoutMessage);
         await WarmupAsync(cancellationToken).ConfigureAwait(false);
+        await _actor.StartAsync(OnReceiveAsync, cancellationToken).ConfigureAwait(false);
     }
 
-    protected override async ValueTask OnReceiveAsync(
+    private async ValueTask OnReceiveAsync(
         DownloadMessage message,
         CancellationToken cancellationToken
     )
@@ -52,23 +54,6 @@ internal class RequestScheduler(
                 }
                 break;
         }
-    }
-
-    protected override async ValueTask DrainAsync()
-    {
-        await foreach (var item in MailboxReader.ReadAllAsync().ConfigureAwait(false))
-        {
-            if (item is DownloadMessage.BlockMessage blockMessage)
-            {
-                blockMessage.Dispose();
-            }
-        }
-
-        foreach (var (_, item) in _pieceBuffers)
-        {
-            item.Dispose();
-        }
-        _pieceBuffers.Clear();
     }
 
     private async ValueTask ProcessBlockAsync(Block block, CancellationToken cancellationToken)
@@ -152,7 +137,7 @@ internal class RequestScheduler(
 
             if (freePeer is not null)
             {
-                Tell(new DownloadMessage.ScheduleMessage(freePeer));
+                _actor.Tell(new DownloadMessage.ScheduleMessage(freePeer));
             }
         }
     }
@@ -231,7 +216,7 @@ internal class RequestScheduler(
     {
         if (!peerConnection.PeerChoking.CurrentValue && peerConnection.AmInterested.CurrentValue)
         {
-            Tell(new DownloadMessage.ScheduleMessage(peerConnection));
+            _actor.Tell(new DownloadMessage.ScheduleMessage(peerConnection));
         }
     }
 
@@ -253,12 +238,31 @@ internal class RequestScheduler(
         var message = new DownloadMessage.BlockMessage(block);
         try
         {
-            await SendAsync(message, cancellationToken).ConfigureAwait(false);
+            await _actor.SendAsync(message, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
             message.Dispose();
             throw;
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _actor.DisposeAsync().ConfigureAwait(false);
+
+        await foreach (var item in _actor.MailboxReader.ReadAllAsync().ConfigureAwait(false))
+        {
+            if (item is DownloadMessage.BlockMessage blockMessage)
+            {
+                blockMessage.Dispose();
+            }
+        }
+
+        foreach (var (_, item) in _pieceBuffers)
+        {
+            item.Dispose();
+        }
+        _pieceBuffers.Clear();
     }
 }

--- a/Netorrent/P2P/Messages/Message.cs
+++ b/Netorrent/P2P/Messages/Message.cs
@@ -58,216 +58,88 @@ internal interface IMessage
 
     public record CancelMessage(int Index, int Begin, int Length) : IMessage;
 
-    public static RentedArray<byte> SerializeChoke(Choke _)
-    {
-        var rentedArray = new RentedArray<byte>(5);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 1);
-            rentedArray.Memory.Span[4] = IdChoke;
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
-    }
+    public static RentedArray<byte> SerializeChoke(Choke _) => SerializeSimple(IdChoke);
 
-    public static RentedArray<byte> SerializeUnChoke(Unchoke _)
-    {
-        var rentedArray = new RentedArray<byte>(5);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 1);
-            rentedArray.Memory.Span[4] = IdUnchoke;
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
-    }
+    public static RentedArray<byte> SerializeUnChoke(Unchoke _) => SerializeSimple(IdUnchoke);
 
-    public static RentedArray<byte> SerializeInterested(Interested _)
-    {
-        var rentedArray = new RentedArray<byte>(5);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 1);
-            rentedArray.Memory.Span[4] = IdInterested;
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
-    }
+    public static RentedArray<byte> SerializeInterested(Interested _) =>
+        SerializeSimple(IdInterested);
 
-    public static RentedArray<byte> SerializeNotInterested(NotInterested _)
+    public static RentedArray<byte> SerializeNotInterested(NotInterested _) =>
+        SerializeSimple(IdNotInterested);
+
+    private static RentedArray<byte> SerializeSimple(byte id)
     {
         var rentedArray = new RentedArray<byte>(5);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 1);
-            rentedArray.Memory.Span[4] = IdNotInterested;
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 1);
+        rentedArray.Memory.Span[4] = id;
+        return rentedArray;
     }
 
     public static RentedArray<byte> SerializeKeepAlive(KeepAlive _)
     {
         var rentedArray = new RentedArray<byte>(4);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 0);
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 0);
+        return rentedArray;
     }
 
     public static RentedArray<byte> SerializeHave(Have have)
     {
         var rentedArray = new RentedArray<byte>(9);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 5);
-            rentedArray.Memory.Span[4] = IdHave;
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[5..], have.Index);
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 5);
+        rentedArray.Memory.Span[4] = IdHave;
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[5..], have.Index);
+        return rentedArray;
     }
 
     public static RentedArray<byte> SerializePort(Port port)
     {
         var rentedArray = new RentedArray<byte>(7);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 5);
-            rentedArray.Memory.Span[4] = IdPort;
-            BinaryPrimitives.WriteUInt16BigEndian(rentedArray.Memory.Span[5..], port.Value);
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 5);
+        rentedArray.Memory.Span[4] = IdPort;
+        BinaryPrimitives.WriteUInt16BigEndian(rentedArray.Memory.Span[5..], port.Value);
+        return rentedArray;
     }
 
     public static RentedArray<byte> SerializeBitfield(BitfieldMessage bitfieldMessage)
     {
         using var bitfieldPayload = bitfieldMessage.Bitfield.ToRentedArray();
         var rentedArray = new RentedArray<byte>(5 + bitfieldPayload.Length);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[..4],
-                1 + bitfieldPayload.Length
-            );
-            rentedArray.Memory.Span[4] = IdBitfield;
-            bitfieldPayload.Memory.CopyTo(rentedArray.Memory[5..]);
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(
+            rentedArray.Memory.Span[..4],
+            1 + bitfieldPayload.Length
+        );
+        rentedArray.Memory.Span[4] = IdBitfield;
+        bitfieldPayload.Memory.CopyTo(rentedArray.Memory[5..]);
+        return rentedArray;
     }
 
-    public static RentedArray<byte> SerializeRequest(RequestBlockMessage requestBlockMessage)
-    {
-        var rentedArray = new RentedArray<byte>(17);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 13);
-            rentedArray.Memory.Span[4] = IdRequest;
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[5..9],
-                requestBlockMessage.Index
-            );
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[9..13],
-                requestBlockMessage.Begin
-            );
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[13..17],
-                requestBlockMessage.Length
-            );
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
-    }
+    public static RentedArray<byte> SerializeRequest(RequestBlockMessage m) =>
+        SerializeThreeInts(IdRequest, m.Index, m.Begin, m.Length);
 
-    public static RentedArray<byte> SerializeCancel(CancelMessage cancelMessage)
+    public static RentedArray<byte> SerializeCancel(CancelMessage m) =>
+        SerializeThreeInts(IdCancel, m.Index, m.Begin, m.Length);
+
+    private static RentedArray<byte> SerializeThreeInts(byte id, int a, int b, int c)
     {
         var rentedArray = new RentedArray<byte>(17);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 13);
-            rentedArray.Memory.Span[4] = IdCancel;
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[5..9],
-                cancelMessage.Index
-            );
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[9..13],
-                cancelMessage.Begin
-            );
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[13..17],
-                cancelMessage.Length
-            );
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 13);
+        rentedArray.Memory.Span[4] = id;
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[5..9], a);
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[9..13], b);
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[13..17], c);
+        return rentedArray;
     }
 
     public static RentedArray<byte> SerializeBlock(BlockMessage blockMessage)
     {
         using var payload = blockMessage.Payload;
         var rentedArray = new RentedArray<byte>(13 + payload.Length);
-        try
-        {
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 9 + payload.Length);
-            rentedArray.Memory.Span[4] = IdPiece;
-            BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[5..9], blockMessage.Index);
-            BinaryPrimitives.WriteInt32BigEndian(
-                rentedArray.Memory.Span[9..13],
-                blockMessage.Begin
-            );
-            payload.Memory.CopyTo(rentedArray.Memory[13..]);
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[..4], 9 + payload.Length);
+        rentedArray.Memory.Span[4] = IdPiece;
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[5..9], blockMessage.Index);
+        BinaryPrimitives.WriteInt32BigEndian(rentedArray.Memory.Span[9..13], blockMessage.Begin);
+        payload.Memory.CopyTo(rentedArray.Memory[13..]);
+        return rentedArray;
     }
 }

--- a/Netorrent/P2P/PeersClient.cs
+++ b/Netorrent/P2P/PeersClient.cs
@@ -17,10 +17,11 @@ internal class PeersClient(
     IPiecePicker piecePicker,
     Bitfield bitField,
     ILogger logger
-) : Actor<PeerConnection>
+) : IAsyncDisposable
 {
     const int MAX_ACTIVE_PEER_COUNT = 100;
 
+    private readonly Actor<PeerConnection> _actor = new();
     private readonly ConcurrentQueue<PeerEndpoint> _knownPeers = [];
     private readonly Subject<PeerEndpoint> _peerConnected = new();
     private readonly List<Task> _peerTasks = [];
@@ -31,7 +32,28 @@ internal class PeersClient(
 
     public Bitfield BitField { get; } = bitField;
 
-    protected override async ValueTask OnReceiveAsync(
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _actor.StartAsync(OnReceiveAsync, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            try
+            {
+                await Task.WhenAll(_peerTasks).ConfigureAwait(false);
+            }
+            catch { }
+
+            var disposeTasks = activePeers.Values.Select(i => i.DisposeAsync().AsTask());
+            await Task.WhenAll(disposeTasks).ConfigureAwait(false);
+            activePeers.Clear();
+            _peerConnected.OnCompleted();
+        }
+    }
+
+    private async ValueTask OnReceiveAsync(
         PeerConnection peerConnection,
         CancellationToken cancellationToken
     )
@@ -42,28 +64,6 @@ internal class PeersClient(
         {
             _peerConnected.OnNext(peerConnection.PeerEndpoint);
             _peerTasks.Add(HandlePeerAsync(peerConnection, cancellationToken));
-        }
-    }
-
-    protected override async ValueTask OnStoppingAsync()
-    {
-        try
-        {
-            await Task.WhenAll(_peerTasks).ConfigureAwait(false);
-        }
-        catch { }
-
-        var disposeTasks = activePeers.Values.Select(i => i.DisposeAsync().AsTask());
-        await Task.WhenAll(disposeTasks).ConfigureAwait(false);
-        activePeers.Clear();
-        _peerConnected.OnCompleted();
-    }
-
-    protected override async ValueTask DrainAsync()
-    {
-        await foreach (var connection in MailboxReader.ReadAllAsync().ConfigureAwait(false))
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -81,7 +81,7 @@ internal class PeersClient(
         );
         try
         {
-            await SendAsync(peerConnection, cancellationToken).ConfigureAwait(false);
+            await _actor.SendAsync(peerConnection, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -166,5 +166,15 @@ internal class PeersClient(
 
         activePeers[peerConnection.PeerEndpoint] = peerConnection;
         return true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _actor.DisposeAsync().ConfigureAwait(false);
+
+        await foreach (var connection in _actor.MailboxReader.ReadAllAsync().ConfigureAwait(false))
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/Netorrent/P2P/PeersClient.cs
+++ b/Netorrent/P2P/PeersClient.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Concurrent;
-using System.Threading.Channels;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
-using Netorrent.Extensions;
+using Netorrent.ActorSystem;
 using Netorrent.P2P.Download;
 using Netorrent.P2P.Messages;
 using Netorrent.P2P.Upload;
@@ -18,16 +17,13 @@ internal class PeersClient(
     IPiecePicker piecePicker,
     Bitfield bitField,
     ILogger logger
-) : IAsyncDisposable
+) : Actor<PeerConnection>
 {
     const int MAX_ACTIVE_PEER_COUNT = 100;
 
     private readonly ConcurrentQueue<PeerEndpoint> _knownPeers = [];
     private readonly Subject<PeerEndpoint> _peerConnected = new();
-    private readonly Channel<PeerConnection> _peerConnections =
-        Channel.CreateBounded<PeerConnection>(
-            new BoundedChannelOptions(128) { SingleReader = true, SingleWriter = false }
-        );
+    private readonly List<Task> _peerTasks = [];
 
     public PeerId PeerId => peerId;
     public Observable<PeerEndpoint> PeerConnected => _peerConnected;
@@ -35,33 +31,39 @@ internal class PeersClient(
 
     public Bitfield BitField { get; } = bitField;
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async ValueTask OnReceiveAsync(
+        PeerConnection peerConnection,
+        CancellationToken cancellationToken
+    )
     {
-        try
+        _peerTasks.RemoveAll(t => t.IsCompleted);
+
+        if (await CanConnectAsync(peerConnection).ConfigureAwait(false))
         {
-            await ProcessPeersAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            var disposeTasks = activePeers.Values.Select(i => i.DisposeAsync().AsTask());
-            await Task.WhenAll(disposeTasks).ConfigureAwait(false);
-            activePeers.Clear();
-            throw;
+            _peerConnected.OnNext(peerConnection.PeerEndpoint);
+            _peerTasks.Add(HandlePeerAsync(peerConnection, cancellationToken));
         }
     }
 
-    private async Task ProcessPeersAsync(CancellationToken cancellationToken)
+    protected override async ValueTask OnStoppingAsync()
     {
-        await foreach (
-            var peerConnection in _peerConnections
-                .Reader.ReadAllAsync(cancellationToken)
-                .ConfigureAwait(false)
-        )
+        try
         {
-            if (await CanConnectAsync(peerConnection).ConfigureAwait(false))
-            {
-                _ = HandlePeerAsync(peerConnection, cancellationToken);
-            }
+            await Task.WhenAll(_peerTasks).ConfigureAwait(false);
+        }
+        catch { }
+
+        var disposeTasks = activePeers.Values.Select(i => i.DisposeAsync().AsTask());
+        await Task.WhenAll(disposeTasks).ConfigureAwait(false);
+        activePeers.Clear();
+        _peerConnected.OnCompleted();
+    }
+
+    protected override async ValueTask DrainAsync()
+    {
+        await foreach (var connection in MailboxReader.ReadAllAsync().ConfigureAwait(false))
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -79,9 +81,7 @@ internal class PeersClient(
         );
         try
         {
-            await _peerConnections
-                .Writer.WriteAsync(peerConnection, cancellationToken)
-                .ConfigureAwait(false);
+            await SendAsync(peerConnection, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -97,16 +97,9 @@ internal class PeersClient(
     {
         try
         {
-            _peerConnected.OnNext(peerConnection.PeerEndpoint);
             await peerConnection.StartAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
-        {
-            activePeers.Remove(peerConnection.PeerEndpoint, out _);
-            await peerConnection.DisposeAsync().ConfigureAwait(false);
-            return;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {
@@ -116,7 +109,9 @@ internal class PeersClient(
                     peerConnection.PeerEndpoint.PeerId
                 );
             }
-
+        }
+        finally
+        {
             activePeers.Remove(peerConnection.PeerEndpoint, out _);
             await peerConnection.DisposeAsync().ConfigureAwait(false);
         }
@@ -171,12 +166,5 @@ internal class PeersClient(
 
         activePeers[peerConnection.PeerEndpoint] = peerConnection;
         return true;
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        var peersDisposeTasks = activePeers.Values.Select(i => i.DisposeAsync().AsTask());
-        await Task.WhenAll(peersDisposeTasks).ConfigureAwait(false);
-        _peerConnected.OnCompleted();
     }
 }

--- a/Netorrent/P2P/Upload/UploadScheduler.cs
+++ b/Netorrent/P2P/Upload/UploadScheduler.cs
@@ -17,23 +17,24 @@ internal class UploadScheduler(
     Bitfield bitfield,
     DataStatistics data,
     ILogger logger
-) : Actor<UploadMessage>, IUploadScheduler
+) : IUploadScheduler
 {
     const int MaxActivePeers = 4; //TODO Add an option for this to be changed or rate based
 
+    private readonly Actor<UploadMessage> _actor = new();
     private static readonly UploadMessage.CheckRoundMessage _checkRoundMessage = new();
     private readonly Lock _cancelLock = new();
     private readonly HashSet<RequestBlock> _requests = [];
 
     private byte _round = 1;
 
-    protected override Task OnStartedAsync(CancellationToken cancellationToken)
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        ScheduleRepeatedly(TimeSpan.Zero, 10.Seconds, _checkRoundMessage);
-        return Task.CompletedTask;
+        _actor.ScheduleRepeatedly(TimeSpan.Zero, 10.Seconds, _checkRoundMessage);
+        return _actor.StartAsync(OnReceiveAsync, cancellationToken);
     }
 
-    protected override async ValueTask OnReceiveAsync(
+    private async ValueTask OnReceiveAsync(
         UploadMessage message,
         CancellationToken cancellationToken
     )
@@ -48,12 +49,6 @@ internal class UploadScheduler(
                     .ConfigureAwait(false);
                 break;
         }
-    }
-
-    protected override ValueTask DrainAsync()
-    {
-        _requests.Clear();
-        return ValueTask.CompletedTask;
     }
 
     private void RunRound()
@@ -241,7 +236,7 @@ internal class UploadScheduler(
     {
         if (peerConnection.PeerInterested.CurrentValue && !peerConnection.AmChoking.CurrentValue)
         {
-            Tell(_checkRoundMessage);
+            _actor.Tell(_checkRoundMessage);
         }
     }
 
@@ -290,7 +285,8 @@ internal class UploadScheduler(
         {
             from.IncrementUploadRequested();
 
-            await SendAsync(new UploadMessage.RequestBlockMessage(request), cancellationToken)
+            await _actor
+                .SendAsync(new UploadMessage.RequestBlockMessage(request), cancellationToken)
                 .ConfigureAwait(false);
         }
     }
@@ -304,5 +300,11 @@ internal class UploadScheduler(
                 cancelled.State = RequestBlockState.Cancelled;
             }
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _actor.DisposeAsync().ConfigureAwait(false);
+        _requests.Clear();
     }
 }

--- a/Netorrent/P2P/Upload/UploadScheduler.cs
+++ b/Netorrent/P2P/Upload/UploadScheduler.cs
@@ -1,5 +1,5 @@
-﻿using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using Netorrent.ActorSystem;
 using Netorrent.Extensions;
 using Netorrent.IO;
 using Netorrent.P2P.Messages;
@@ -17,66 +17,43 @@ internal class UploadScheduler(
     Bitfield bitfield,
     DataStatistics data,
     ILogger logger
-) : IUploadScheduler
+) : Actor<UploadMessage>, IUploadScheduler
 {
     const int MaxActivePeers = 4; //TODO Add an option for this to be changed or rate based
 
-    private readonly Channel<UploadMessage> _uploadMessagesChannel =
-        Channel.CreateBounded<UploadMessage>(
-            new BoundedChannelOptions(128) { SingleWriter = false, SingleReader = true }
-        );
+    private static readonly UploadMessage.CheckRoundMessage _checkRoundMessage = new();
     private readonly Lock _cancelLock = new();
     private readonly HashSet<RequestBlock> _requests = [];
-    private static readonly UploadMessage.CheckRoundMessage _checkRoundMessage = new();
-    private readonly TimeSpan _interval = 10.Seconds;
 
     private byte _round = 1;
-    private CancellationTokenSource? _cts;
-    private Task? _runningTask;
-    private bool _disposed;
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    protected override Task OnStartedAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _runningTask = Task.RunUntilFirstCompletesAsync(
-            [ScheduleRoundsAsync, ProcessUploadMessagesAsync],
-            _cts
-        );
-        return _runningTask;
+        ScheduleRepeatedly(TimeSpan.Zero, 10.Seconds, _checkRoundMessage);
+        return Task.CompletedTask;
     }
 
-    public async Task ScheduleRoundsAsync(CancellationToken cancellationToken)
+    protected override async ValueTask OnReceiveAsync(
+        UploadMessage message,
+        CancellationToken cancellationToken
+    )
     {
-        while (true)
+        switch (message)
         {
-            await _uploadMessagesChannel
-                .Writer.WriteAsync(_checkRoundMessage, cancellationToken)
-                .ConfigureAwait(false);
-            await Task.Delay(_interval, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    public async Task ProcessUploadMessagesAsync(CancellationToken cancellationToken)
-    {
-        await foreach (
-            var uploadMessage in _uploadMessagesChannel.Reader.ReadAllAsync(cancellationToken)
-        )
-        {
-            if (uploadMessage is UploadMessage.CheckRoundMessage)
-            {
+            case UploadMessage.CheckRoundMessage:
                 RunRound();
-                continue;
-            }
-
-            if (uploadMessage is UploadMessage.RequestBlockMessage requestBlockMessage)
-            {
+                break;
+            case UploadMessage.RequestBlockMessage requestBlockMessage:
                 await ProcessRequestAsync(requestBlockMessage.RequestBlock, cancellationToken)
                     .ConfigureAwait(false);
-                continue;
-            }
+                break;
         }
+    }
+
+    protected override ValueTask DrainAsync()
+    {
+        _requests.Clear();
+        return ValueTask.CompletedTask;
     }
 
     private void RunRound()
@@ -264,7 +241,7 @@ internal class UploadScheduler(
     {
         if (peerConnection.PeerInterested.CurrentValue && !peerConnection.AmChoking.CurrentValue)
         {
-            _uploadMessagesChannel.Writer.TryWrite(_checkRoundMessage);
+            Tell(_checkRoundMessage);
         }
     }
 
@@ -313,11 +290,7 @@ internal class UploadScheduler(
         {
             from.IncrementUploadRequested();
 
-            await _uploadMessagesChannel
-                .Writer.WriteAsync(
-                    new UploadMessage.RequestBlockMessage(request),
-                    cancellationToken
-                )
+            await SendAsync(new UploadMessage.RequestBlockMessage(request), cancellationToken)
                 .ConfigureAwait(false);
         }
     }
@@ -330,35 +303,6 @@ internal class UploadScheduler(
             {
                 cancelled.State = RequestBlockState.Cancelled;
             }
-        }
-    }
-
-    private async ValueTask DrainChannelsAsync()
-    {
-        await foreach (var _ in _uploadMessagesChannel.Reader.ReadAllAsync().ConfigureAwait(false))
-        { }
-        _requests.Clear();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (!_disposed)
-        {
-            _disposed = true;
-            _cts?.Cancel();
-            _uploadMessagesChannel.Writer.TryComplete();
-
-            try
-            {
-                if (_runningTask is not null)
-                {
-                    await _runningTask.ConfigureAwait(false);
-                }
-            }
-            catch { }
-
-            await DrainChannelsAsync().ConfigureAwait(false);
-            _cts?.Dispose();
         }
     }
 }

--- a/Netorrent/Tracker/Http/HttpTracker.cs
+++ b/Netorrent/Tracker/Http/HttpTracker.cs
@@ -59,7 +59,8 @@ internal class HttpTracker(
         foreach (var endpoint in response.Peers)
             await channelWriter.WriteAsync(endpoint, cancellationToken).ConfigureAwait(false);
 
-        _actor.ScheduleOnce(response.Interval.Seconds, new TrackerMessage.AnnounceMessage(null));
+        if (message is not TrackerMessage.CompletedMessage)
+            _actor.ScheduleOnce(response.Interval.Seconds, new TrackerMessage.AnnounceMessage(null));
     }
 
     private async Task<HttpTrackerResponse> AnnounceAsync(

--- a/Netorrent/Tracker/Http/HttpTracker.cs
+++ b/Netorrent/Tracker/Http/HttpTracker.cs
@@ -1,5 +1,6 @@
-﻿using System.Net;
+using System.Net;
 using System.Threading.Channels;
+using Netorrent.ActorSystem;
 using Netorrent.Exceptions;
 using Netorrent.Extensions;
 using Netorrent.P2P.Messages;
@@ -20,46 +21,59 @@ internal class HttpTracker(
     ChannelWriter<IPEndPoint> channelWriter
 ) : ITracker
 {
+    private readonly Actor<TrackerMessage> _actor = new();
+    private Timer? _announceTimer;
+    private IDisposable? _completedSubscription;
+    private static readonly TrackerMessage.CompletedMessage _completedMessage = new();
+
     public async ValueTask StartAsync(CancellationToken cancellationToken)
     {
-        var response = await AnnounceAsync(
-                myBitfield.IsComplete ? Events.Completed : Events.Started,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
+        var initialEvent = myBitfield.IsComplete ? Events.Completed : Events.Started;
+        _actor.Tell(new TrackerMessage.AnnounceMessage(initialEvent));
 
-        using var completeDisposable = myBitfield.StateChanged.SubscribeAwait(
-            async (value, ct) =>
-            {
-                if (myBitfield.IsComplete)
-                {
-                    response = await AnnounceAsync(Events.Completed, cancellationToken: ct)
-                        .ConfigureAwait(false);
-                }
-            },
-            configureAwait: false
-        );
-
-        foreach (var iPEndPoint in response.Peers)
+        _completedSubscription = myBitfield.StateChanged.Subscribe(_ =>
         {
-            await channelWriter.WriteAsync(iPEndPoint, cancellationToken).ConfigureAwait(false);
-        }
+            if (myBitfield.IsComplete)
+                _actor.Tell(_completedMessage);
+        });
 
-        while (!cancellationToken.IsCancellationRequested)
+        await _actor.StartAsync(OnReceiveAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask OnReceiveAsync(
+        TrackerMessage message,
+        CancellationToken cancellationToken
+    )
+    {
+        string? @event = message switch
         {
-            var interval = response.Interval.Seconds;
+            TrackerMessage.AnnounceMessage m => m.Event,
+            TrackerMessage.CompletedMessage => Events.Completed,
+            _ => null,
+        };
 
-            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+        if (message is TrackerMessage.CompletedMessage)
+            _announceTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-            var newResponse = await AnnounceAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
-            response = newResponse;
+        var response = await AnnounceAsync(@event, cancellationToken).ConfigureAwait(false);
 
-            foreach (var iPEndPoint in response.Peers)
-            {
-                await channelWriter.WriteAsync(iPEndPoint, cancellationToken).ConfigureAwait(false);
-            }
-        }
+        foreach (var endpoint in response.Peers)
+            await channelWriter.WriteAsync(endpoint, cancellationToken).ConfigureAwait(false);
+
+        ScheduleNextAnnounce(response.Interval.Seconds);
+    }
+
+    private void ScheduleNextAnnounce(TimeSpan delay)
+    {
+        if (_announceTimer is null)
+            _announceTimer = new Timer(
+                _ => _actor.Tell(new TrackerMessage.AnnounceMessage(null)),
+                null,
+                delay,
+                Timeout.InfiniteTimeSpan
+            );
+        else
+            _announceTimer.Change(delay, Timeout.InfiniteTimeSpan);
     }
 
     private async Task<HttpTrackerResponse> AnnounceAsync(
@@ -99,5 +113,20 @@ internal class HttpTracker(
     public async ValueTask StopAsync(CancellationToken cancellationToken)
     {
         await AnnounceAsync(Events.Stopped, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _completedSubscription?.Dispose();
+
+        if (_announceTimer is not null)
+        {
+            await _announceTimer.DisposeAsync().ConfigureAwait(false);
+            _announceTimer = null;
+        }
+
+        await _actor.DisposeAsync().ConfigureAwait(false);
+
+        await foreach (var _ in _actor.MailboxReader.ReadAllAsync().ConfigureAwait(false)) { }
     }
 }

--- a/Netorrent/Tracker/Http/HttpTracker.cs
+++ b/Netorrent/Tracker/Http/HttpTracker.cs
@@ -22,7 +22,6 @@ internal class HttpTracker(
 ) : ITracker
 {
     private readonly Actor<TrackerMessage> _actor = new();
-    private Timer? _announceTimer;
     private IDisposable? _completedSubscription;
     private static readonly TrackerMessage.CompletedMessage _completedMessage = new();
 
@@ -53,27 +52,14 @@ internal class HttpTracker(
         };
 
         if (message is TrackerMessage.CompletedMessage)
-            _announceTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _actor.CancelScheduled();
 
         var response = await AnnounceAsync(@event, cancellationToken).ConfigureAwait(false);
 
         foreach (var endpoint in response.Peers)
             await channelWriter.WriteAsync(endpoint, cancellationToken).ConfigureAwait(false);
 
-        ScheduleNextAnnounce(response.Interval.Seconds);
-    }
-
-    private void ScheduleNextAnnounce(TimeSpan delay)
-    {
-        if (_announceTimer is null)
-            _announceTimer = new Timer(
-                _ => _actor.Tell(new TrackerMessage.AnnounceMessage(null)),
-                null,
-                delay,
-                Timeout.InfiniteTimeSpan
-            );
-        else
-            _announceTimer.Change(delay, Timeout.InfiniteTimeSpan);
+        _actor.ScheduleOnce(response.Interval.Seconds, new TrackerMessage.AnnounceMessage(null));
     }
 
     private async Task<HttpTrackerResponse> AnnounceAsync(
@@ -118,15 +104,6 @@ internal class HttpTracker(
     public async ValueTask DisposeAsync()
     {
         _completedSubscription?.Dispose();
-
-        if (_announceTimer is not null)
-        {
-            await _announceTimer.DisposeAsync().ConfigureAwait(false);
-            _announceTimer = null;
-        }
-
         await _actor.DisposeAsync().ConfigureAwait(false);
-
-        await foreach (var _ in _actor.MailboxReader.ReadAllAsync().ConfigureAwait(false)) { }
     }
 }

--- a/Netorrent/Tracker/Http/HttpTracker.cs
+++ b/Netorrent/Tracker/Http/HttpTracker.cs
@@ -60,7 +60,10 @@ internal class HttpTracker(
             await channelWriter.WriteAsync(endpoint, cancellationToken).ConfigureAwait(false);
 
         if (message is not TrackerMessage.CompletedMessage)
-            _actor.ScheduleOnce(response.Interval.Seconds, new TrackerMessage.AnnounceMessage(null));
+            _actor.ScheduleOnce(
+                response.Interval.Seconds,
+                new TrackerMessage.AnnounceMessage(null)
+            );
     }
 
     private async Task<HttpTrackerResponse> AnnounceAsync(

--- a/Netorrent/Tracker/ITracker.cs
+++ b/Netorrent/Tracker/ITracker.cs
@@ -1,6 +1,6 @@
 ﻿namespace Netorrent.Tracker;
 
-internal interface ITracker
+internal interface ITracker : IAsyncDisposable
 {
     public ValueTask StartAsync(CancellationToken cancellationToken);
     public ValueTask StopAsync(CancellationToken cancellationToken);

--- a/Netorrent/Tracker/TrackerClient.cs
+++ b/Netorrent/Tracker/TrackerClient.cs
@@ -56,6 +56,11 @@ internal class TrackerClient(
                     {
                         logger.LogError(ex, "Error Announcing");
                     }
+
+                    if (Ipv4 is not null)
+                        await Ipv4.DisposeAsync().ConfigureAwait(false);
+                    if (Ipv6 is not null)
+                        await Ipv6.DisposeAsync().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException oce)
                     when (oce.CancellationToken == cancellationToken)
@@ -66,10 +71,12 @@ internal class TrackerClient(
                         if (Ipv4 is not null)
                         {
                             await Ipv4.StopAsync(ct.Token).ConfigureAwait(false);
+                            await Ipv4.DisposeAsync().ConfigureAwait(false);
                         }
                         if (Ipv6 is not null)
                         {
                             await Ipv6.StopAsync(ct.Token).ConfigureAwait(false);
+                            await Ipv6.DisposeAsync().ConfigureAwait(false);
                         }
 
                         Promote(urls, url);

--- a/Netorrent/Tracker/TrackerMessage.cs
+++ b/Netorrent/Tracker/TrackerMessage.cs
@@ -1,0 +1,8 @@
+namespace Netorrent.Tracker;
+
+internal abstract record TrackerMessage
+{
+    internal record AnnounceMessage(string? Event) : TrackerMessage;
+
+    internal record CompletedMessage : TrackerMessage;
+}

--- a/Netorrent/Tracker/Udp/Request/UdpTrackerConnectRequest.cs
+++ b/Netorrent/Tracker/Udp/Request/UdpTrackerConnectRequest.cs
@@ -16,25 +16,17 @@ internal record UdpTrackerConnectRequest(
     public RentedArray<byte> ToMemoryRented()
     {
         var rentedArray = new RentedArray<byte>(SIZE);
-        try
-        {
-            var memory = rentedArray.Memory;
-            int offset = 0;
+        var span = rentedArray.Memory.Span;
+        int offset = 0;
 
-            BinaryPrimitives.WriteInt64BigEndian(memory.Span[offset..], ProtocolId);
-            offset += 8;
+        BinaryPrimitives.WriteInt64BigEndian(span[offset..], ProtocolId);
+        offset += 8;
 
-            BinaryPrimitives.WriteInt32BigEndian(memory.Span[offset..], Action);
-            offset += 4;
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], Action);
+        offset += 4;
 
-            BinaryPrimitives.WriteInt32BigEndian(memory.Span[offset..], TransactionId);
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], TransactionId);
 
-            return rentedArray;
-        }
-        catch
-        {
-            rentedArray.Dispose();
-            throw;
-        }
+        return rentedArray;
     }
 }

--- a/Netorrent/Tracker/Udp/Request/UdpTrackerRequest.cs
+++ b/Netorrent/Tracker/Udp/Request/UdpTrackerRequest.cs
@@ -29,92 +29,78 @@ internal record UdpTrackerRequest(
 
     public RentedArray<byte> ToMemoryRented()
     {
+        if (InfoHash.Data.Length != 20)
+            throw new ArgumentException("InfoHash must be 20 bytes", nameof(InfoHash));
+
+        var peerBytes = PeerId.ToBytes();
+        if (peerBytes.Length != 20)
+            throw new ArgumentException("PeerId must be 20 bytes", nameof(PeerId));
+
         var rentedArray = new RentedArray<byte>(SIZE);
-        try
-        {
-            var memory = rentedArray.Memory;
-            var span = memory.Span;
+        var span = rentedArray.Memory.Span;
+        int offset = 0;
 
-            int offset = 0;
+        BinaryPrimitives.WriteInt64BigEndian(span[offset..], ConnectionId);
+        offset += 8;
 
-            BinaryPrimitives.WriteInt64BigEndian(span[offset..], ConnectionId);
-            offset += 8;
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], 1);
+        offset += 4;
 
-            BinaryPrimitives.WriteInt32BigEndian(span[offset..], 1);
-            offset += 4;
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], TransactionId);
+        offset += 4;
 
-            BinaryPrimitives.WriteInt32BigEndian(span[offset..], TransactionId);
-            offset += 4;
+        InfoHash.Data.Span.CopyTo(span[offset..]);
+        offset += 20;
 
-            if (InfoHash.Data.Length != 20)
+        peerBytes.CopyTo(span[offset..]);
+        offset += 20;
+
+        BinaryPrimitives.WriteInt64BigEndian(span[offset..], Downloaded);
+        offset += 8;
+
+        BinaryPrimitives.WriteInt64BigEndian(span[offset..], Left);
+        offset += 8;
+
+        BinaryPrimitives.WriteInt64BigEndian(span[offset..], Uploaded);
+        offset += 8;
+
+        BinaryPrimitives.WriteInt32BigEndian(
+            span[offset..],
+            Event switch
             {
-                throw new ArgumentException("InfoHash must be 20 bytes", nameof(InfoHash));
+                Events.Completed => 1,
+                Events.Started => 2,
+                Events.Stopped => 3,
+                _ => 0,
             }
+        );
+        offset += 4;
 
-            InfoHash.Data.Span.CopyTo(span[offset..]);
-            offset += 20;
-
-            var peerBytes = PeerId.ToBytes();
-            if (peerBytes.Length != 20)
-            {
-                throw new ArgumentException("PeerId must be 20 bytes", nameof(PeerId));
-            }
-
-            peerBytes.CopyTo(span[offset..]);
-            offset += 20;
-
-            BinaryPrimitives.WriteInt64BigEndian(span[offset..], Downloaded);
-            offset += 8;
-
-            BinaryPrimitives.WriteInt64BigEndian(span[offset..], Left);
-            offset += 8;
-
-            BinaryPrimitives.WriteInt64BigEndian(span[offset..], Uploaded);
-            offset += 8;
-
-            BinaryPrimitives.WriteInt32BigEndian(
-                span[offset..],
-                Event switch
-                {
-                    Events.Completed => 1,
-                    Events.Started => 2,
-                    Events.Stopped => 3,
-                    _ => 0,
-                }
-            );
-            offset += 4;
-
-            if (
-                IpAddress is not null
-                && (
-                    IpAddress.IsIPv4MappedToIPv6 == true
-                    || IpAddress.AddressFamily == AddressFamily.InterNetwork
-                )
+        if (
+            IpAddress is not null
+            && (
+                IpAddress.IsIPv4MappedToIPv6 == true
+                || IpAddress.AddressFamily == AddressFamily.InterNetwork
             )
-            {
-                var ipv4Bytes = IpAddress.MapToIPv4().GetAddressBytes();
-                ipv4Bytes.CopyTo(span[offset..]);
-            }
-            else
-            {
-                BinaryPrimitives.WriteInt32BigEndian(span[offset..], 0);
-            }
-            offset += 4;
-
-            BinaryPrimitives.WriteInt32BigEndian(span[offset..], Key);
-            offset += 4;
-
-            BinaryPrimitives.WriteInt32BigEndian(span[offset..], NumWant);
-            offset += 4;
-
-            BinaryPrimitives.WriteUInt16BigEndian(span[offset..], Port);
-
-            return rentedArray;
-        }
-        catch
+        )
         {
-            rentedArray.Dispose();
-            throw;
+            var ipv4Bytes = IpAddress.MapToIPv4().GetAddressBytes();
+            ipv4Bytes.CopyTo(span[offset..]);
         }
+        else
+        {
+            BinaryPrimitives.WriteInt32BigEndian(span[offset..], 0);
+        }
+        offset += 4;
+
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], Key);
+        offset += 4;
+
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], NumWant);
+        offset += 4;
+
+        BinaryPrimitives.WriteUInt16BigEndian(span[offset..], Port);
+
+        return rentedArray;
     }
 }

--- a/Netorrent/Tracker/Udp/UdpTracker.cs
+++ b/Netorrent/Tracker/Udp/UdpTracker.cs
@@ -66,10 +66,11 @@ internal class UdpTracker(
         foreach (var peer in _lastResponse.Peers)
             await channelWriter.WriteAsync(peer, cancellationToken).ConfigureAwait(false);
 
-        _actor.ScheduleOnce(
-            _lastResponse.Interval.Seconds,
-            new TrackerMessage.AnnounceMessage(null)
-        );
+        if (message is not TrackerMessage.CompletedMessage)
+            _actor.ScheduleOnce(
+                _lastResponse.Interval.Seconds,
+                new TrackerMessage.AnnounceMessage(null)
+            );
     }
 
     public async Task<UdpTrackerConnectResponse> ConnectAsync(

--- a/Netorrent/Tracker/Udp/UdpTracker.cs
+++ b/Netorrent/Tracker/Udp/UdpTracker.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Threading.Channels;
+using Netorrent.ActorSystem;
 using Netorrent.Exceptions;
 using Netorrent.Extensions;
 using Netorrent.P2P.Messages;
@@ -24,54 +25,62 @@ internal class UdpTracker(
 {
     private UdpTrackerResponse? _lastResponse;
     private readonly Guid _trackerId = Guid.CreateVersion7();
+    private readonly Actor<TrackerMessage> _actor = new();
+    private Timer? _announceTimer;
+    private IDisposable? _completedSubscription;
+    private static readonly TrackerMessage.CompletedMessage _completedMessage = new();
 
     public async ValueTask StartAsync(CancellationToken cancellationToken)
     {
         await ConnectAsync(iPEndPoint, cancellationToken).ConfigureAwait(false);
 
-        _lastResponse = await AnnounceAndReceiveAsync(
-                iPEndPoint,
-                @event: myBitfield.IsComplete ? Events.Completed : Events.Started,
-                cancellationToken: cancellationToken
-            )
+        var initialEvent = myBitfield.IsComplete ? Events.Completed : Events.Started;
+        _actor.Tell(new TrackerMessage.AnnounceMessage(initialEvent));
+
+        _completedSubscription = myBitfield.StateChanged.Subscribe(_ =>
+        {
+            if (myBitfield.IsComplete)
+                _actor.Tell(_completedMessage);
+        });
+
+        await _actor.StartAsync(OnReceiveAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask OnReceiveAsync(
+        TrackerMessage message,
+        CancellationToken cancellationToken
+    )
+    {
+        string? @event = message switch
+        {
+            TrackerMessage.AnnounceMessage m => m.Event,
+            TrackerMessage.CompletedMessage => Events.Completed,
+            _ => null,
+        };
+
+        if (message is TrackerMessage.CompletedMessage)
+            _announceTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+        _lastResponse = await AnnounceAndReceiveAsync(iPEndPoint, @event, cancellationToken)
             .ConfigureAwait(false);
 
-        using var completeDisposable = myBitfield.StateChanged.SubscribeAwait(
-            async (value, ct) =>
-            {
-                if (myBitfield.IsComplete)
-                {
-                    _lastResponse = await AnnounceAndReceiveAsync(
-                            iPEndPoint,
-                            @event: Events.Completed,
-                            cancellationToken: cancellationToken
-                        )
-                        .ConfigureAwait(false);
-                }
-            },
-            configureAwait: false
-        );
-
         foreach (var peer in _lastResponse.Peers)
-        {
             await channelWriter.WriteAsync(peer, cancellationToken).ConfigureAwait(false);
-        }
 
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var interval = _lastResponse.Interval.Seconds;
-            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+        ScheduleNextAnnounce(_lastResponse.Interval.Seconds);
+    }
 
-            var newResponse = await AnnounceAndReceiveAsync(iPEndPoint, null, cancellationToken)
-                .ConfigureAwait(false);
-
-            _lastResponse = newResponse;
-
-            foreach (var peer in _lastResponse.Peers)
-            {
-                await channelWriter.WriteAsync(peer, cancellationToken).ConfigureAwait(false);
-            }
-        }
+    private void ScheduleNextAnnounce(TimeSpan delay)
+    {
+        if (_announceTimer is null)
+            _announceTimer = new Timer(
+                _ => _actor.Tell(new TrackerMessage.AnnounceMessage(null)),
+                null,
+                delay,
+                Timeout.InfiniteTimeSpan
+            );
+        else
+            _announceTimer.Change(delay, Timeout.InfiniteTimeSpan);
     }
 
     public async Task<UdpTrackerConnectResponse> ConnectAsync(
@@ -182,5 +191,20 @@ internal class UdpTracker(
             await AnnounceAsync(iPEndPoint, Events.Stopped, cancellationToken)
                 .ConfigureAwait(false);
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _completedSubscription?.Dispose();
+
+        if (_announceTimer is not null)
+        {
+            await _announceTimer.DisposeAsync().ConfigureAwait(false);
+            _announceTimer = null;
+        }
+
+        await _actor.DisposeAsync().ConfigureAwait(false);
+
+        await foreach (var _ in _actor.MailboxReader.ReadAllAsync().ConfigureAwait(false)) { }
     }
 }

--- a/Netorrent/Tracker/Udp/UdpTracker.cs
+++ b/Netorrent/Tracker/Udp/UdpTracker.cs
@@ -26,7 +26,6 @@ internal class UdpTracker(
     private UdpTrackerResponse? _lastResponse;
     private readonly Guid _trackerId = Guid.CreateVersion7();
     private readonly Actor<TrackerMessage> _actor = new();
-    private Timer? _announceTimer;
     private IDisposable? _completedSubscription;
     private static readonly TrackerMessage.CompletedMessage _completedMessage = new();
 
@@ -59,7 +58,7 @@ internal class UdpTracker(
         };
 
         if (message is TrackerMessage.CompletedMessage)
-            _announceTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _actor.CancelScheduled();
 
         _lastResponse = await AnnounceAndReceiveAsync(iPEndPoint, @event, cancellationToken)
             .ConfigureAwait(false);
@@ -67,20 +66,10 @@ internal class UdpTracker(
         foreach (var peer in _lastResponse.Peers)
             await channelWriter.WriteAsync(peer, cancellationToken).ConfigureAwait(false);
 
-        ScheduleNextAnnounce(_lastResponse.Interval.Seconds);
-    }
-
-    private void ScheduleNextAnnounce(TimeSpan delay)
-    {
-        if (_announceTimer is null)
-            _announceTimer = new Timer(
-                _ => _actor.Tell(new TrackerMessage.AnnounceMessage(null)),
-                null,
-                delay,
-                Timeout.InfiniteTimeSpan
-            );
-        else
-            _announceTimer.Change(delay, Timeout.InfiniteTimeSpan);
+        _actor.ScheduleOnce(
+            _lastResponse.Interval.Seconds,
+            new TrackerMessage.AnnounceMessage(null)
+        );
     }
 
     public async Task<UdpTrackerConnectResponse> ConnectAsync(
@@ -106,7 +95,7 @@ internal class UdpTracker(
         CancellationToken cancellationToken
     )
     {
-        var (_, request) = await BuildRequestAsync(iPEndPoint, @event, cancellationToken)
+        var request = await BuildRequestAsync(iPEndPoint, @event, cancellationToken)
             .ConfigureAwait(false);
 
         try
@@ -131,7 +120,7 @@ internal class UdpTracker(
         CancellationToken cancellationToken
     )
     {
-        var (_, request) = await BuildRequestAsync(iPEndPoint, @event, cancellationToken)
+        var request = await BuildRequestAsync(iPEndPoint, @event, cancellationToken)
             .ConfigureAwait(false);
 
         try
@@ -150,7 +139,7 @@ internal class UdpTracker(
         }
     }
 
-    private async Task<(long ConnectionId, UdpTrackerRequest Request)> BuildRequestAsync(
+    private async Task<UdpTrackerRequest> BuildRequestAsync(
         IPEndPoint iPEndPoint,
         string? @event,
         CancellationToken cancellationToken
@@ -167,7 +156,7 @@ internal class UdpTracker(
             connectionId = response.ConnectionId;
         }
 
-        var updRequest = new UdpTrackerRequest(
+        return new UdpTrackerRequest(
             iPEndPoint,
             infoHash,
             peerId,
@@ -180,8 +169,6 @@ internal class UdpTracker(
             TransactionId: udpTrackerHandler.MakeTransactionId(),
             NumWant: 200
         );
-
-        return (connectionId.Value, updRequest);
     }
 
     public async ValueTask StopAsync(CancellationToken cancellationToken)
@@ -196,15 +183,6 @@ internal class UdpTracker(
     public async ValueTask DisposeAsync()
     {
         _completedSubscription?.Dispose();
-
-        if (_announceTimer is not null)
-        {
-            await _announceTimer.DisposeAsync().ConfigureAwait(false);
-            _announceTimer = null;
-        }
-
         await _actor.DisposeAsync().ConfigureAwait(false);
-
-        await foreach (var _ in _actor.MailboxReader.ReadAllAsync().ConfigureAwait(false)) { }
     }
 }


### PR DESCRIPTION
Extract duplicated Channel<T> + CTS + dispose boilerplate from RequestScheduler, UploadScheduler, and PeersClient into a reusable Actor<TMessage> base class. Replaces manual timer loops with System.Threading.Timer and fire-and-forget peer tasks with tracked child tasks.