### PR TITLE
Implement tracker scrape (HTTP and UDP)

### DIFF
--- a/Netorrent.Tests.Integration/Torrents/RealTorrentTests.cs
+++ b/Netorrent.Tests.Integration/Torrents/RealTorrentTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Netorrent.TorrentFile;
+using Shouldly;
 
 namespace Netorrent.Tests.Integration.Torrents;
 
@@ -20,5 +21,21 @@ public class RealTorrentTests
         cancellationToken.Register(torrent.Stop);
         await torrent.StartAsync();
         await torrent.Completion;
+    }
+
+    [Test]
+    public async Task Should_Scrape_Real_Torrent(CancellationToken cancellationToken)
+    {
+        await using var torrentClient = new TorrentClient(o => o with { Logger = Logger });
+        await using var torrent = await torrentClient.LoadTorrentAsync(
+            "Data/debian-13.3.0-amd64-netinst.iso.torrent",
+            "Output",
+            cancellationToken: cancellationToken
+        );
+
+        var result = await torrent.ScrapeAsync(cancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Seeders.ShouldBeGreaterThan(0);
     }
 }

--- a/Netorrent.Tests/Fakes/FakeHttpMessageHandler.cs
+++ b/Netorrent.Tests/Fakes/FakeHttpMessageHandler.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net;
+using Netorrent.TorrentFile;
+using Netorrent.TorrentFile.FileStructure;
 using Netorrent.Tracker.Http;
 
 namespace Netorrent.Tests.Fakes;
@@ -24,4 +26,13 @@ internal class FakeHttpTrackerHandler(IPEndPoint[] ips, TimeSpan interval, Excep
                 }
             )
             : ValueTask.FromException<HttpTrackerResponse>(error);
+
+    public ValueTask<ScrapeInfo?> ScrapeAsync(
+        string announceUrl,
+        InfoHash infoHash,
+        CancellationToken cancellationToken
+    ) =>
+        error is null
+            ? ValueTask.FromResult<ScrapeInfo?>(new ScrapeInfo(ips.Length, 0, 0))
+            : ValueTask.FromException<ScrapeInfo?>(error);
 }

--- a/Netorrent.Tests/Fakes/FakeUdpTrackerTransactionManager.cs
+++ b/Netorrent.Tests/Fakes/FakeUdpTrackerTransactionManager.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Net;
+using Netorrent.TorrentFile;
+using Netorrent.TorrentFile.FileStructure;
 using Netorrent.Tracker.Udp;
 using Netorrent.Tracker.Udp.Response;
 
@@ -68,6 +70,15 @@ internal sealed class FakeUdpTrackerTransactionManager(
         );
         return Task.FromResult((T)receivePacket);
     }
+
+    public Task<ScrapeInfo?> ScrapeAsync(
+        IPEndPoint endPoint,
+        InfoHash infoHash,
+        CancellationToken cancellationToken
+    ) =>
+        error is not null
+            ? Task.FromException<ScrapeInfo?>(error)
+            : Task.FromResult<ScrapeInfo?>(new ScrapeInfo(peers.Length, 0, 0));
 
     public ValueTask DisposeAsync()
     {

--- a/Netorrent.Tests/PublicApi/ApiTest.My_API_Has_No_Changes.approved.txt
+++ b/Netorrent.Tests/PublicApi/ApiTest.My_API_Has_No_Changes.approved.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
 [assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/xBaank/Netorrent")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]
@@ -247,6 +247,13 @@ namespace Netorrent.TorrentFile.Options
 }
 namespace Netorrent.TorrentFile
 {
+    public class ScrapeInfo : System.IEquatable<Netorrent.TorrentFile.ScrapeInfo>
+    {
+        public ScrapeInfo(int Seeders, int Leechers, int Downloaded) { }
+        public int Downloaded { get; init; }
+        public int Leechers { get; init; }
+        public int Seeders { get; init; }
+    }
     public enum State
     {
         Started = 0,
@@ -265,6 +272,7 @@ namespace Netorrent.TorrentFile
         public System.Threading.Tasks.ValueTask CheckAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.Task ExportAsync(string outputPath, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<Netorrent.TorrentFile.ScrapeInfo?> ScrapeAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask StartAsync() { }
         public void Stop() { }
         public System.Threading.Tasks.ValueTask StopAsync() { }

--- a/Netorrent.Tests/Tracker/ScrapeTests.cs
+++ b/Netorrent.Tests/Tracker/ScrapeTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netorrent.Extensions;
+using Netorrent.P2P.Messages;
+using Netorrent.Tests.Fakes;
+using Netorrent.TorrentFile.Options;
+using Netorrent.Tracker;
+using Shouldly;
+
+namespace Netorrent.Tests.Tracker;
+
+[Timeout(10_000)]
+public class ScrapeTests
+{
+    private static IPEndPoint[] DefaultPeers =>
+        [
+            new IPEndPoint(IPAddress.Parse("127.0.0.1"), 6881),
+            new IPEndPoint(IPAddress.Parse("127.0.0.2"), 6882),
+        ];
+
+    private static TrackerClient CreateTrackerClient(
+        TrackerHandlers handlers,
+        string announceUrl = "http://tracker.example.com/announce"
+    ) =>
+        new TrackerClient(
+            new Bitfield(5),
+            handlers,
+            UsedTrackers.Http | UsedTrackers.Udp,
+            6881,
+            new(3),
+            new(),
+            Channel.CreateUnbounded<IPEndPoint>().Writer,
+            [
+                [announceUrl],
+            ],
+            new byte[20],
+            NullLogger.Instance
+        );
+
+    [Test]
+    public async Task Should_Get_Scrape_From_Http_Tracker(CancellationToken cancellationToken)
+    {
+        var fake = new FakeHttpTrackerHandler(DefaultPeers, 1.Seconds);
+        var handlers = new TrackerHandlers(fake, null, null, null);
+        var client = CreateTrackerClient(handlers);
+
+        var result = await client.ScrapeAsync(cancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Seeders.ShouldBe(DefaultPeers.Length);
+        result.Leechers.ShouldBe(0);
+        result.Downloaded.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task Should_Get_Scrape_From_Udp_Tracker(CancellationToken cancellationToken)
+    {
+        await using var fake = new FakeUdpTrackerTransactionManager(DefaultPeers, 1.Seconds);
+        var handlers = new TrackerHandlers(null, fake, null, null);
+        var client = CreateTrackerClient(handlers, "udp://127.0.0.1:6969/announce");
+
+        var result = await client.ScrapeAsync(cancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Seeders.ShouldBe(DefaultPeers.Length);
+    }
+
+    [Test]
+    public async Task Should_Return_Null_When_Http_Tracker_Scrape_Fails(
+        CancellationToken cancellationToken
+    )
+    {
+        var fake = new FakeHttpTrackerHandler(
+            DefaultPeers,
+            1.Seconds,
+            new Exception("scrape error")
+        );
+        var handlers = new TrackerHandlers(fake, null, null, null);
+        var client = CreateTrackerClient(handlers);
+
+        var result = await client.ScrapeAsync(cancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task Should_Return_Null_When_Udp_Tracker_Scrape_Fails(
+        CancellationToken cancellationToken
+    )
+    {
+        await using var fake = new FakeUdpTrackerTransactionManager(
+            DefaultPeers,
+            1.Seconds,
+            new Exception("scrape error")
+        );
+        var handlers = new TrackerHandlers(null, fake, null, null);
+        var client = CreateTrackerClient(handlers, "udp://127.0.0.1:6969/announce");
+
+        var result = await client.ScrapeAsync(cancellationToken);
+
+        result.ShouldBeNull();
+    }
+}

--- a/Netorrent/TorrentFile/ScrapeInfo.cs
+++ b/Netorrent/TorrentFile/ScrapeInfo.cs
@@ -1,0 +1,3 @@
+namespace Netorrent.TorrentFile;
+
+public record ScrapeInfo(int Seeders, int Leechers, int Downloaded);

--- a/Netorrent/TorrentFile/Torrent.cs
+++ b/Netorrent/TorrentFile/Torrent.cs
@@ -283,6 +283,15 @@ public sealed class Torrent : IAsyncDisposable
         State = State.Stopped;
     }
 
+    /// <summary>
+    /// Returns swarm statistics from the first responsive tracker, or null if no tracker supports scrape.
+    /// </summary>
+    public ValueTask<ScrapeInfo?> ScrapeAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _trackerClient.ScrapeAsync(cancellationToken);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (!_disposed)

--- a/Netorrent/TorrentFile/TorrentClient.cs
+++ b/Netorrent/TorrentFile/TorrentClient.cs
@@ -123,7 +123,7 @@ public sealed class TorrentClient : IAsyncDisposable
         CancellationToken cancellationToken = default
     )
     {
-        var stream = File.Open(path, FileMode.Open, FileAccess.Read);
+        var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
 
         await using var decoder = new BDecoder(stream);
         var decoded = await decoder.DecodeAsync(cancellationToken).ConfigureAwait(false);

--- a/Netorrent/Tracker/Http/HttpTrackerHandler.cs
+++ b/Netorrent/Tracker/Http/HttpTrackerHandler.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Netorrent.Bencoding;
 using Netorrent.Bencoding.Structs;
+using Netorrent.Extensions;
 using Netorrent.TorrentFile;
 using Netorrent.TorrentFile.FileStructure;
 
@@ -52,41 +53,34 @@ internal class HttpTrackerHandler(HttpClient httpClient) : IHttpTrackerHandler
         await using var decoder = new BDecoder(stream);
         var root = await decoder.DecodeAsync(cancellationToken).ConfigureAwait(false);
 
-        if (root is not BDictionary dict)
+        if (root.As<BDictionary>() is not { } dict)
             return null;
 
-        if (
-            !dict.Elements.TryGetValue("files", out var filesNode)
-            || filesNode is not BDictionary filesDict
-        )
+        if (dict.Elements.GetValueOrDefault("files").As<BDictionary>() is not { } filesDict)
             return null;
 
         var hashKey = new BString(infoHash.Data.ToArray());
-        if (
-            !filesDict.Elements.TryGetValue(hashKey, out var torrentNode)
-            || torrentNode is not BDictionary torrentDict
-        )
+        if (filesDict.Elements.GetValueOrDefault(hashKey).As<BDictionary>() is not { } torrentDict)
             return null;
 
-        var seeders = torrentDict.Elements.TryGetValue("complete", out var comp)
-            ? (int)((BInt)comp).Data
-            : 0;
-        var leechers = torrentDict.Elements.TryGetValue("incomplete", out var incomp)
-            ? (int)((BInt)incomp).Data
-            : 0;
-        var downloaded = torrentDict.Elements.TryGetValue("downloaded", out var dl)
-            ? (int)((BInt)dl).Data
-            : 0;
+        var seeders = (int)(
+            torrentDict.Elements.GetValueOrDefault("complete").As<BInt>()?.Data ?? 0
+        );
+        var leechers = (int)(
+            torrentDict.Elements.GetValueOrDefault("incomplete").As<BInt>()?.Data ?? 0
+        );
+        var downloaded = (int)(
+            torrentDict.Elements.GetValueOrDefault("downloaded").As<BInt>()?.Data ?? 0
+        );
 
         return new ScrapeInfo(seeders, leechers, downloaded);
     }
 
     private static string? GetScrapeUrl(string announceUrl)
     {
-        var idx = announceUrl.LastIndexOf("/announce", StringComparison.OrdinalIgnoreCase);
-        if (idx < 0)
+        if (!announceUrl.Contains("/announce", StringComparison.OrdinalIgnoreCase))
             return null;
-        return announceUrl[..idx] + "/scrape" + announceUrl[(idx + "/announce".Length)..];
+        return announceUrl.Replace("/announce", "/scrape", StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()

--- a/Netorrent/Tracker/Http/HttpTrackerHandler.cs
+++ b/Netorrent/Tracker/Http/HttpTrackerHandler.cs
@@ -1,4 +1,10 @@
-﻿namespace Netorrent.Tracker.Http;
+using System.Text;
+using Netorrent.Bencoding;
+using Netorrent.Bencoding.Structs;
+using Netorrent.TorrentFile;
+using Netorrent.TorrentFile.FileStructure;
+
+namespace Netorrent.Tracker.Http;
 
 internal class HttpTrackerHandler(HttpClient httpClient) : IHttpTrackerHandler
 {
@@ -15,6 +21,72 @@ internal class HttpTrackerHandler(HttpClient httpClient) : IHttpTrackerHandler
         return await HttpTrackerResponse
             .FromHttpResponseAsync(response, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    public async ValueTask<ScrapeInfo?> ScrapeAsync(
+        string announceUrl,
+        InfoHash infoHash,
+        CancellationToken cancellationToken
+    )
+    {
+        var scrapeUrl = GetScrapeUrl(announceUrl);
+        if (scrapeUrl is null)
+            return null;
+
+        var sb = new StringBuilder(scrapeUrl);
+        sb.Append(scrapeUrl.Contains('?') ? '&' : '?');
+        sb.Append("info_hash=");
+        foreach (var b in infoHash.Data.Span)
+        {
+            sb.Append('%').Append(b.ToString("X2"));
+        }
+
+        var response = await httpClient
+            .GetAsync(sb.ToString(), cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var stream = await response
+            .Content.ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var decoder = new BDecoder(stream);
+        var root = await decoder.DecodeAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root is not BDictionary dict)
+            return null;
+
+        if (
+            !dict.Elements.TryGetValue("files", out var filesNode)
+            || filesNode is not BDictionary filesDict
+        )
+            return null;
+
+        var hashKey = new BString(infoHash.Data.ToArray());
+        if (
+            !filesDict.Elements.TryGetValue(hashKey, out var torrentNode)
+            || torrentNode is not BDictionary torrentDict
+        )
+            return null;
+
+        var seeders = torrentDict.Elements.TryGetValue("complete", out var comp)
+            ? (int)((BInt)comp).Data
+            : 0;
+        var leechers = torrentDict.Elements.TryGetValue("incomplete", out var incomp)
+            ? (int)((BInt)incomp).Data
+            : 0;
+        var downloaded = torrentDict.Elements.TryGetValue("downloaded", out var dl)
+            ? (int)((BInt)dl).Data
+            : 0;
+
+        return new ScrapeInfo(seeders, leechers, downloaded);
+    }
+
+    private static string? GetScrapeUrl(string announceUrl)
+    {
+        var idx = announceUrl.LastIndexOf("/announce", StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+            return null;
+        return announceUrl[..idx] + "/scrape" + announceUrl[(idx + "/announce".Length)..];
     }
 
     public void Dispose()

--- a/Netorrent/Tracker/Http/IHttpTrackerHandler.cs
+++ b/Netorrent/Tracker/Http/IHttpTrackerHandler.cs
@@ -1,10 +1,19 @@
-﻿namespace Netorrent.Tracker.Http;
+using Netorrent.TorrentFile;
+using Netorrent.TorrentFile.FileStructure;
+
+namespace Netorrent.Tracker.Http;
 
 internal interface IHttpTrackerHandler : IDisposable
 {
     ValueTask<HttpTrackerResponse> SendAsync(
         string url,
         HttpTrackerRequest httpTrackerRequest,
+        CancellationToken cancellationToken
+    );
+
+    ValueTask<ScrapeInfo?> ScrapeAsync(
+        string announceUrl,
+        InfoHash infoHash,
         CancellationToken cancellationToken
     );
 }

--- a/Netorrent/Tracker/TrackerClient.cs
+++ b/Netorrent/Tracker/TrackerClient.cs
@@ -6,6 +6,7 @@ using Netorrent.Exceptions;
 using Netorrent.Extensions;
 using Netorrent.P2P.Messages;
 using Netorrent.Statistics;
+using Netorrent.TorrentFile;
 using Netorrent.TorrentFile.FileStructure;
 using Netorrent.TorrentFile.Options;
 using Netorrent.Tracker.Http;
@@ -227,6 +228,76 @@ internal class TrackerClient(
         }
 
         return (trackerv4, trackerv6);
+    }
+
+    public async ValueTask<ScrapeInfo?> ScrapeAsync(CancellationToken cancellationToken)
+    {
+        foreach (var urls in announceList)
+        {
+            foreach (var url in urls)
+            {
+                var uri = Uri.CreateOrNull(url);
+                if (uri is null)
+                    continue;
+
+                try
+                {
+                    ScrapeInfo? result = uri.Scheme switch
+                    {
+                        "http"
+                        or "https"
+                            when usedTrackers.HasFlag(UsedTrackers.Http)
+                                && trackerHandlers.HttpTrackerHandlerIpv4 is not null =>
+                            await trackerHandlers
+                                .HttpTrackerHandlerIpv4.ScrapeAsync(
+                                    url,
+                                    infoHash,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false),
+                        "udp"
+                            when usedTrackers.HasFlag(UsedTrackers.Udp)
+                                && trackerHandlers.UdpTrackerHandlerIpv4 is not null
+                                && uri.Port > 0 => await ScrapeUdpAsync(
+                                uri,
+                                trackerHandlers.UdpTrackerHandlerIpv4,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false),
+                        _ => null,
+                    };
+
+                    if (result is not null)
+                        return result;
+                }
+                catch (Exception ex)
+                {
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug(ex, "Scrape failed for {url}", url);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async ValueTask<ScrapeInfo?> ScrapeUdpAsync(
+        Uri uri,
+        IUdpTrackerHandler handler,
+        CancellationToken cancellationToken
+    )
+    {
+        var (ipv4, _) = await Dns.GetHostAdressesOrEmptyAsync(uri, cancellationToken)
+            .ConfigureAwait(false);
+        if (ipv4 is null)
+            return null;
+
+        var endPoint = new IPEndPoint(ipv4, uri.Port);
+        return await handler
+            .ScrapeAsync(endPoint, infoHash, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private (ITracker? Ipv4, ITracker? Ipv6) LogUnknownTracker(string scheme)

--- a/Netorrent/Tracker/TrackerClient.cs
+++ b/Netorrent/Tracker/TrackerClient.cs
@@ -232,56 +232,53 @@ internal class TrackerClient(
 
     public async ValueTask<ScrapeInfo?> ScrapeAsync(CancellationToken cancellationToken)
     {
-        foreach (var urls in announceList)
+        foreach (var url in announceList.SelectMany(urls => urls))
         {
-            foreach (var url in urls)
+            var uri = Uri.CreateOrNull(url);
+            if (uri is null)
+                continue;
+
+            try
             {
-                var uri = Uri.CreateOrNull(url);
-                if (uri is null)
-                    continue;
-
-                try
-                {
-                    ScrapeInfo? result = uri.Scheme switch
-                    {
-                        "http"
-                        or "https"
-                            when usedTrackers.HasFlag(UsedTrackers.Http)
-                                && trackerHandlers.HttpTrackerHandlerIpv4 is not null =>
-                            await trackerHandlers
-                                .HttpTrackerHandlerIpv4.ScrapeAsync(
-                                    url,
-                                    infoHash,
-                                    cancellationToken
-                                )
-                                .ConfigureAwait(false),
-                        "udp"
-                            when usedTrackers.HasFlag(UsedTrackers.Udp)
-                                && trackerHandlers.UdpTrackerHandlerIpv4 is not null
-                                && uri.Port > 0 => await ScrapeUdpAsync(
-                                uri,
-                                trackerHandlers.UdpTrackerHandlerIpv4,
-                                cancellationToken
-                            )
-                            .ConfigureAwait(false),
-                        _ => null,
-                    };
-
-                    if (result is not null)
-                        return result;
-                }
-                catch (Exception ex)
-                {
-                    if (logger.IsEnabled(LogLevel.Debug))
-                    {
-                        logger.LogDebug(ex, "Scrape failed for {url}", url);
-                    }
-                }
+                var result = await ScrapeSingleAsync(uri, url, cancellationToken)
+                    .ConfigureAwait(false);
+                if (result is not null)
+                    return result;
+            }
+            catch (Exception ex)
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                    logger.LogDebug(ex, "Scrape failed for {url}", url);
             }
         }
 
         return null;
     }
+
+    private async ValueTask<ScrapeInfo?> ScrapeSingleAsync(
+        Uri uri,
+        string url,
+        CancellationToken cancellationToken
+    ) =>
+        uri.Scheme switch
+        {
+            "http"
+            or "https"
+                when usedTrackers.HasFlag(UsedTrackers.Http)
+                    && trackerHandlers.HttpTrackerHandlerIpv4 is not null => await trackerHandlers
+                .HttpTrackerHandlerIpv4.ScrapeAsync(url, infoHash, cancellationToken)
+                .ConfigureAwait(false),
+            "udp"
+                when usedTrackers.HasFlag(UsedTrackers.Udp)
+                    && trackerHandlers.UdpTrackerHandlerIpv4 is not null
+                    && uri.Port > 0 => await ScrapeUdpAsync(
+                    uri,
+                    trackerHandlers.UdpTrackerHandlerIpv4,
+                    cancellationToken
+                )
+                .ConfigureAwait(false),
+            _ => null,
+        };
 
     private async ValueTask<ScrapeInfo?> ScrapeUdpAsync(
         Uri uri,

--- a/Netorrent/Tracker/Udp/IUdpTrackerHandler.cs
+++ b/Netorrent/Tracker/Udp/IUdpTrackerHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+using System.Net;
+using Netorrent.TorrentFile;
+using Netorrent.TorrentFile.FileStructure;
 using Netorrent.Tracker.Udp.Response;
 
 namespace Netorrent.Tracker.Udp
@@ -24,5 +26,11 @@ namespace Netorrent.Tracker.Udp
             CancellationToken cancellationToken
         )
             where T : IUdpTrackerReceivePacket;
+
+        Task<ScrapeInfo?> ScrapeAsync(
+            IPEndPoint endPoint,
+            InfoHash infoHash,
+            CancellationToken cancellationToken
+        );
     }
 }

--- a/Netorrent/Tracker/Udp/Request/UdpTrackerScrapeRequest.cs
+++ b/Netorrent/Tracker/Udp/Request/UdpTrackerScrapeRequest.cs
@@ -1,0 +1,39 @@
+using System.Buffers.Binary;
+using System.Net;
+using Netorrent.Other;
+using Netorrent.TorrentFile.FileStructure;
+
+namespace Netorrent.Tracker.Udp.Request;
+
+internal record UdpTrackerScrapeRequest(
+    IPEndPoint IPEndPoint,
+    long ConnectionId,
+    int TransactionId,
+    InfoHash InfoHash
+) : IUdpTrackerSendPacket
+{
+    private const int SIZE = 36;
+
+    public RentedArray<byte> ToMemoryRented()
+    {
+        if (InfoHash.Data.Length != 20)
+            throw new ArgumentException("InfoHash must be 20 bytes", nameof(InfoHash));
+
+        var rentedArray = new RentedArray<byte>(SIZE);
+        var span = rentedArray.Memory.Span;
+        int offset = 0;
+
+        BinaryPrimitives.WriteInt64BigEndian(span[offset..], ConnectionId);
+        offset += 8;
+
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], 2); // action = scrape
+        offset += 4;
+
+        BinaryPrimitives.WriteInt32BigEndian(span[offset..], TransactionId);
+        offset += 4;
+
+        InfoHash.Data.Span.CopyTo(span[offset..]);
+
+        return rentedArray;
+    }
+}

--- a/Netorrent/Tracker/Udp/Response/UdpTrackerScrapeResponse.cs
+++ b/Netorrent/Tracker/Udp/Response/UdpTrackerScrapeResponse.cs
@@ -1,0 +1,26 @@
+using System.Buffers.Binary;
+
+namespace Netorrent.Tracker.Udp.Response;
+
+internal record UdpTrackerScrapeResponse(
+    int TransactionId,
+    int Seeders,
+    int Downloaded,
+    int Leechers
+) : IUdpTrackerReceivePacket
+{
+    public const int Action = 2;
+
+    public static UdpTrackerScrapeResponse From(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 20)
+            throw new ArgumentException("Invalid scrape response length", nameof(data));
+
+        int transactionId = BinaryPrimitives.ReadInt32BigEndian(data.Slice(4, 4));
+        int seeders = BinaryPrimitives.ReadInt32BigEndian(data.Slice(8, 4));
+        int downloaded = BinaryPrimitives.ReadInt32BigEndian(data.Slice(12, 4));
+        int leechers = BinaryPrimitives.ReadInt32BigEndian(data.Slice(16, 4));
+
+        return new(transactionId, seeders, downloaded, leechers);
+    }
+}

--- a/Netorrent/Tracker/Udp/UdpTrackerHandler.cs
+++ b/Netorrent/Tracker/Udp/UdpTrackerHandler.cs
@@ -3,6 +3,8 @@ using System.Collections.Concurrent;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using Netorrent.Extensions;
+using Netorrent.TorrentFile;
+using Netorrent.TorrentFile.FileStructure;
 using Netorrent.Tracker.Udp.Client;
 using Netorrent.Tracker.Udp.Exceptions;
 using Netorrent.Tracker.Udp.Request;
@@ -88,6 +90,7 @@ internal class UdpTrackerHandler : IUdpTrackerHandler
                         result.Buffer,
                         result.RemoteEndPoint.AddressFamily
                     ),
+                    UdpTrackerScrapeResponse.Action => UdpTrackerScrapeResponse.From(result.Buffer),
                     UdpTrackerErrorResponse.Action => UdpTrackerErrorResponse.From(result.Buffer),
                     _ => null,
                 };
@@ -330,6 +333,37 @@ internal class UdpTrackerHandler : IUdpTrackerHandler
             .ConfigureAwait(false);
         _connectionIdByTracker[trackerId] = connectResponse.ConnectionId;
         return connectResponse;
+    }
+
+    public async Task<ScrapeInfo?> ScrapeAsync(
+        IPEndPoint endPoint,
+        InfoHash infoHash,
+        CancellationToken cancellationToken
+    )
+    {
+        var trackerId = Guid.NewGuid();
+        var connectionId = GetConnectionIdOrNull(trackerId);
+        if (connectionId is null || IsOutdated(connectionId.Value))
+        {
+            var connectResponse = await ConnectAsync(endPoint, trackerId, cancellationToken)
+                .ConfigureAwait(false);
+            connectionId = connectResponse.ConnectionId;
+        }
+
+        var request = new UdpTrackerScrapeRequest(
+            endPoint,
+            connectionId.Value,
+            MakeTransactionId(),
+            infoHash
+        );
+        var response = await SendAndReceiveAsync<UdpTrackerScrapeResponse>(
+                request,
+                trackerId,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return new ScrapeInfo(response.Seeders, response.Leechers, response.Downloaded);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
Adds ScrapeAsync to Torrent, TrackerClient, IHttpTrackerHandler, and IUdpTrackerHandler. HTTP scrape derives the scrape URL from the announce URL; UDP scrape uses action=2. Also fixes FileShare.Read on torrent file open to allow concurrent test access.