### PR TITLE
Add configurable bencoding depth limit to BDecoder and TorrentClientO…

### DIFF
--- a/Netorrent.Tests/Bencoding/BDecoderTests.cs
+++ b/Netorrent.Tests/Bencoding/BDecoderTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Netorrent.Bencoding;
 using Netorrent.Bencoding.Structs;
+using Netorrent.Exceptions;
 using Netorrent.Tests.Bencoding.Data;
 using Shouldly;
 
@@ -80,6 +81,84 @@ public class BDecoderTests
         var decoded = await decoder.DecodeAsync(cancellationToken);
 
         decoded.ShouldBeEquivalentTo(actual);
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(5)]
+    [Arguments(64)]
+    public async Task Should_Decode_Structure_At_Exact_Depth_Limit(
+        int maxDepth,
+        CancellationToken cancellationToken
+    )
+    {
+        // N nested lists → innermost decoded at depth N-1.
+        // To hit exactly maxDepth, use maxDepth+1 lists.
+        var n = maxDepth + 1;
+        var input = new string('l', n) + new string('e', n);
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var stream = new MemoryStream(bytes);
+        await using var decoder = new BDecoder(stream, maxDepth);
+
+        var decoded = await decoder.DecodeAsync(cancellationToken);
+
+        decoded.ShouldBeOfType<BList>();
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(5)]
+    [Arguments(64)]
+    public async Task Should_Throw_When_Depth_Exceeds_Limit(
+        int maxDepth,
+        CancellationToken cancellationToken
+    )
+    {
+        // maxDepth+2 lists → innermost decoded at depth maxDepth+1 > maxDepth → throws.
+        var n = maxDepth + 2;
+        var input = new string('l', n) + new string('e', n);
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var stream = new MemoryStream(bytes);
+        await using var decoder = new BDecoder(stream, maxDepth);
+
+        await Should.ThrowAsync<BencodingException>(async () =>
+            await decoder.DecodeAsync(cancellationToken)
+        );
+    }
+
+    [Test]
+    public async Task Should_Throw_When_Default_Depth_Limit_Exceeded(
+        CancellationToken cancellationToken
+    )
+    {
+        // 66 lists → innermost at depth 65 > default limit of 64.
+        const int n = 66;
+        var input = new string('l', n) + new string('e', n);
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var stream = new MemoryStream(bytes);
+        await using var decoder = new BDecoder(stream);
+
+        await Should.ThrowAsync<BencodingException>(async () =>
+            await decoder.DecodeAsync(cancellationToken)
+        );
+    }
+
+    [Test]
+    public async Task Should_Throw_On_Deeply_Nested_Dictionary(CancellationToken cancellationToken)
+    {
+        // d1:x d1:x ... i0e e e e
+        const int maxDepth = 4;
+        const int depth = maxDepth + 1;
+        var input =
+            string.Concat(Enumerable.Repeat("d1:x", depth)) + "i0e" + new string('e', depth);
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var stream = new MemoryStream(bytes);
+        await using var decoder = new BDecoder(stream, maxDepth);
+
+        await Should.ThrowAsync<BencodingException>(async () =>
+            await decoder.DecodeAsync(cancellationToken)
+        );
     }
 
     [Test]

--- a/Netorrent.Tests/PublicApi/ApiTest.My_API_Has_No_Changes.approved.txt
+++ b/Netorrent.Tests/PublicApi/ApiTest.My_API_Has_No_Changes.approved.txt
@@ -232,7 +232,8 @@ namespace Netorrent.TorrentFile.Options
 {
     public class TorrentClientOptions : System.IEquatable<Netorrent.TorrentFile.Options.TorrentClientOptions>
     {
-        public TorrentClientOptions(Microsoft.Extensions.Logging.ILogger Logger, int ListenPort, System.Net.IPAddress? ListenIpv4Address, System.Net.IPAddress? ListenIpv6Address, Netorrent.TorrentFile.Options.UsedTrackers UsedTrackers) { }
+        public TorrentClientOptions(Microsoft.Extensions.Logging.ILogger Logger, int ListenPort, System.Net.IPAddress? ListenIpv4Address, System.Net.IPAddress? ListenIpv6Address, Netorrent.TorrentFile.Options.UsedTrackers UsedTrackers, int BencodingMaxDepth = 64) { }
+        public int BencodingMaxDepth { get; init; }
         public System.Net.IPAddress? ListenIpv4Address { get; init; }
         public System.Net.IPAddress? ListenIpv6Address { get; init; }
         public int ListenPort { get; init; }

--- a/Netorrent/Bencoding/BDecoder.cs
+++ b/Netorrent/Bencoding/BDecoder.cs
@@ -6,7 +6,7 @@ using Netorrent.Exceptions;
 
 namespace Netorrent.Bencoding;
 
-internal sealed class BDecoder(Stream stream)
+internal sealed class BDecoder(Stream stream, int maxDepth = 64)
 {
     private readonly PipeReader reader = PipeReader.Create(stream);
 
@@ -24,7 +24,7 @@ internal sealed class BDecoder(Stream stream)
 
             var seqReader = new SequenceReader<byte>(buffer);
 
-            if (TryDecode(ref seqReader, out var node))
+            if (TryDecode(ref seqReader, out var node, depth: 0))
             {
                 reader.AdvanceTo(seqReader.Position);
                 if (seqReader.Remaining > 0)
@@ -45,10 +45,16 @@ internal sealed class BDecoder(Stream stream)
 
     private bool TryDecode(
         ref SequenceReader<byte> reader,
-        [NotNullWhen(true)] out IBencodingNode? node
+        [NotNullWhen(true)] out IBencodingNode? node,
+        int depth
     )
     {
         node = null;
+
+        if (depth > maxDepth)
+        {
+            throw new BencodingException($"Maximum nesting depth of {maxDepth} exceeded");
+        }
 
         if (!reader.TryPeek(out var b))
         {
@@ -59,8 +65,8 @@ internal sealed class BDecoder(Stream stream)
         {
             >= (byte)'0' and <= (byte)'9' => TryDecodeString(ref reader, out node),
             (byte)'i' => TryDecodeInt(ref reader, out node),
-            (byte)'l' => TryDecodeList(ref reader, out node),
-            (byte)'d' => TryDecodeDictionary(ref reader, out node),
+            (byte)'l' => TryDecodeList(ref reader, out node, depth),
+            (byte)'d' => TryDecodeDictionary(ref reader, out node, depth),
             _ => throw new BencodingException($"Invalid Token: {b}"),
         };
     }
@@ -159,7 +165,8 @@ internal sealed class BDecoder(Stream stream)
 
     private bool TryDecodeList(
         ref SequenceReader<byte> reader,
-        [NotNullWhen(true)] out IBencodingNode? node
+        [NotNullWhen(true)] out IBencodingNode? node,
+        int depth
     )
     {
         node = null;
@@ -181,7 +188,7 @@ internal sealed class BDecoder(Stream stream)
                 return true;
             }
 
-            if (!TryDecode(ref reader, out var item))
+            if (!TryDecode(ref reader, out var item, depth + 1))
             {
                 return false;
             }
@@ -192,7 +199,8 @@ internal sealed class BDecoder(Stream stream)
 
     private bool TryDecodeDictionary(
         ref SequenceReader<byte> reader,
-        [NotNullWhen(true)] out IBencodingNode? node
+        [NotNullWhen(true)] out IBencodingNode? node,
+        int depth
     )
     {
         node = null;
@@ -219,7 +227,7 @@ internal sealed class BDecoder(Stream stream)
                 return false;
             }
 
-            if (!TryDecode(ref reader, out var value))
+            if (!TryDecode(ref reader, out var value, depth + 1))
             {
                 return false;
             }

--- a/Netorrent/TorrentFile/Options/TorrentClientOptions.cs
+++ b/Netorrent/TorrentFile/Options/TorrentClientOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Microsoft.Extensions.Logging;
 using Netorrent.Extensions;
 
@@ -14,7 +14,8 @@ public record TorrentClientOptions(
     int ListenPort,
     IPAddress? ListenIpv4Address,
     IPAddress? ListenIpv6Address,
-    UsedTrackers UsedTrackers
+    UsedTrackers UsedTrackers,
+    int BencodingMaxDepth = 64
 )
 {
     /// <summary>

--- a/Netorrent/TorrentFile/TorrentClient.cs
+++ b/Netorrent/TorrentFile/TorrentClient.cs
@@ -125,7 +125,7 @@ public sealed class TorrentClient : IAsyncDisposable
     {
         var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-        await using var decoder = new BDecoder(stream);
+        await using var decoder = new BDecoder(stream, _options.BencodingMaxDepth);
         var decoded = await decoder.DecodeAsync(cancellationToken).ConfigureAwait(false);
         if (decoded is not BDictionary bDictionary)
         {


### PR DESCRIPTION
Prevents stack exhaustion from pathologically nested .torrent files. BDecoder now accepts a maxDepth parameter (default 64); TorrentClientOptions exposes BencodingMaxDepth as a constructor parameter so callers can tune it.